### PR TITLE
feat: add dark and light theme

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -46,15 +46,20 @@ let isRunning = false;
 // ====== Thème (persistance localStorage) ======
 (function initTheme() {
   const root = document.documentElement;
-  const saved = localStorage.getItem("theme") || "light";
-  root.setAttribute("data-theme", saved);
-  themeBtn.textContent = saved === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  const logo = document.getElementById("logo");
+  const saved = localStorage.getItem("theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const theme = saved || (prefersDark ? "dark" : "light");
+  root.setAttribute("data-theme", theme);
+  themeBtn.textContent = theme === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  if (logo) logo.src = theme === "dark" ? "/static/logo_white.png" : "/static/logo.png";
 
   themeBtn.addEventListener("click", () => {
     const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
     root.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
     themeBtn.textContent = next === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+    if (logo) logo.src = next === "dark" ? "/static/logo_white.png" : "/static/logo.png";
   });
 })();
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,70 +1,73 @@
 :root {
-  --bg: #0f1115;
-  --card: #151821;
-  --text: #e6e7ee;
-  --muted: #9aa0aa;
-  --accent: #6ea8fe;
-  --accent-2: #84e1bc;
-  --border: #2a2f3a;
-  --shadow: 0 10px 30px rgba(0,0,0,0.35);
-  --radius: 16px;
+  --accent: #4F46E5;
+  --accent-hover: #6366F1;
+  --accent-2: #22D3EE;
+}
+
+:root[data-theme="dark"] {
+  --body-bg: radial-gradient(circle at top, #0f172a, #0b1020),
+              linear-gradient(120deg, rgba(31,42,68,0.4), rgba(16,52,74,0.4));
+  --text-primary: #E6ECF2;
+  --text-secondary: #AAB4C0;
+  --panel-bg: rgba(18, 24, 38, 0.55);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --panel-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+:root[data-theme="light"] {
+  --body-bg: radial-gradient(circle at top, #F4F7FF, #EAF0FF),
+              linear-gradient(120deg, rgba(234,242,255,0.6), rgba(230,246,255,0.6));
+  --text-primary: #0B1220;
+  --text-secondary: #4B5563;
+  --panel-bg: rgba(255, 255, 255, 0.65);
+  --panel-border: rgba(15, 23, 42, 0.10);
+  --panel-shadow: 0 16px 50px rgba(16, 24, 40, 0.15);
 }
 
 * { box-sizing: border-box; }
 html, body { height: 100%; }
+[hidden] { display: none !important; }
 body {
   margin: 0;
-  background: linear-gradient(180deg, #0f1115, #0b0d12);
-  color: var(--text);
+  background: var(--body-bg);
+  color: var(--text-primary);
   font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
 }
 
-.container {
-  width: 100%;
-  max-width: 980px;
-  margin: 32px auto;
-  padding: 0 16px;
-}
+.container { width: 100%; max-width: 980px; margin: 0 auto; padding: 0 16px; }
 
-h1 {
-  font-size: 28px;
-  margin: 0 0 6px;
-  letter-spacing: 0.2px;
-}
-.subtitle { color: var(--muted); margin: 0; }
+header { height: 72px; }
+.header-row { height: 100%; display: flex; align-items: center; justify-content: space-between; }
+.header-row img { height: 28px; width: auto; }
 
 .card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  backdrop-filter: blur(16px);
+  box-shadow: var(--panel-shadow);
   padding: 20px;
+  margin-top: 32px;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 16px;
-}
+h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: .2px; }
+.subtitle { color: var(--text-secondary); margin: 0 0 24px; }
 
+.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
 .field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
 .field.full { grid-column: 1 / -1; }
-label { color: var(--muted); font-size: 14px; }
+
+label { color: var(--text-secondary); font-size: 14px; }
 select, input[type="file"], input[type="password"] {
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0f131b;
-  color: var(--text);
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--text-primary);
 }
-small { color: var(--muted); }
+small { color: var(--text-secondary); }
 
-.actions {
-  grid-column: 1 / -1;
-  display: flex;
-  gap: 10px;
-  margin-top: 8px;
-}
+.actions { grid-column: 1 / -1; display: flex; gap: 10px; margin-top: 8px; }
 
 button, .button {
   display: inline-flex; align-items: center; justify-content: center;
@@ -72,59 +75,37 @@ button, .button {
   border-radius: 10px;
   border: 1px solid transparent;
   background: var(--accent);
-  color: #0c0e13;
+  color: #fff;
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
-  transition: transform .05s ease;
+  transition: filter .2s ease, box-shadow .2s ease;
 }
-button:active { transform: translateY(1px); }
-button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
-
-/* === bouton "Arrêter" rouge === */
-button.danger {
-  background: #e33c3c;
-  color: #fff;
-  border-color: #b92d2d;
-}
+button:not(.ghost):not(.danger):hover,
+.button:not(.ghost):not(.danger):hover { background: var(--accent-hover); box-shadow: 0 4px 14px rgba(0,0,0,0.1); }
+button.ghost { background: transparent; border-color: var(--panel-border); color: var(--text-primary); }
+button.ghost:hover { filter: brightness(1.05); box-shadow: 0 4px 14px rgba(0,0,0,0.05); }
+button.danger { background: #e5484d; color: #fff; }
 button.danger:hover { filter: brightness(0.95); }
 
-.status { margin-top: 18px; }
-.progress-wrap {
-  height: 10px; border-radius: 999px; background: #0f131b; border: 1px solid var(--border);
-  overflow: hidden;
-}
-.progress {
-  height: 100%; width: 0%;
-  background: linear-gradient(90deg, var(--accent), var(--accent-2));
-  transition: width .25s ease;
-}
+#toggle-theme { min-width: 160px; }
 
-.meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
-.badge {
-  display: inline-block; padding: 4px 8px; border-radius: 999px; background: #1c2230; border: 1px solid var(--border);
-  color: var(--text); font-size: 12px;
-}
+*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.status { margin-top: 18px; }
+.progress-wrap { height: 10px; border-radius: 999px; background: transparent; border: 1px solid var(--panel-border); overflow: hidden; }
+.progress { height: 100%; width: 0%; background: linear-gradient(90deg, var(--accent), var(--accent-2)); transition: width .25s ease; }
+
+.meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--text-secondary); }
+.badge { display: inline-block; padding: 4px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--panel-border); color: var(--text-primary); font-size: 12px; }
 
 .files-list { margin-top: 14px; display: grid; gap: 10px; }
-.file-row {
-  display: grid; gap: 8px;
-  background: #0f131b; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
-}
+.file-row { display: grid; gap: 8px; background: transparent; border: 1px solid var(--panel-border); border-radius: 12px; padding: 10px; }
 .file-row .name { font-weight: 600; }
-.file-row .row-progress { height: 6px; background:#0b0d12; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
-.file-row .row-progress > div {
-  height:100%; width:0%;
-  background: linear-gradient(90deg, var(--accent-2), var(--accent));
-  transition: width .25s ease;
-}
-.file-row .state { font-size: 12px; color: var(--muted); }
+.file-row .row-progress { height: 6px; background: transparent; border:1px solid var(--panel-border); border-radius:999px; overflow:hidden; }
+.file-row .row-progress > div { height:100%; width:0%; background: linear-gradient(90deg, var(--accent-2), var(--accent)); transition: width .25s ease; }
+.file-row .state { font-size: 12px; color: var(--text-secondary); }
 
-.logs {
-  margin-top: 16px; max-height: 320px; overflow: auto;
-  background: #0b0d12; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-  white-space: pre-wrap; word-break: break-word;
-}
+.logs { margin-top: 16px; max-height: 320px; overflow: auto; background: transparent; border: 1px solid var(--panel-border); border-radius: 12px; padding: 12px; white-space: pre-wrap; word-break: break-word; }
 
-.download { margin-top: 16px; }
-footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
+footer.muted { color: var(--text-secondary); text-align: center; margin: 24px 0; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,125 +6,18 @@
     <title>Transcripteur Whisper</title>
     <link rel="stylesheet" href="/static/style.css" />
     <link rel="icon" href="/static/icon.ico" type="image/x-icon">
-
-    <style>
-      /* Thèmes via variables CSS (persistées avec data-theme sur <html>) */
-      :root[data-theme="dark"] {
-        --bg: #0f1115;
-        --card: #151821;
-        --text: #e6e7ee;
-        --muted: #9aa0aa;
-        --accent: #6ea8fe;
-        --accent-2: #84e1bc;
-        --border: #2a2f3a;
-        --btn-fg: #0c0e13;
-      }
-      :root[data-theme="light"] {
-        --bg: #f6f7fb;
-        --card: #ffffff;
-        --text: #151821;
-        --muted: #5b6472;
-        --accent: #2f6df6;
-        --accent-2: #25b78b;
-        --border: #e4e7ee;
-        --btn-fg: #ffffff;
-      }
-
-      html, body { height: 100%; }
-      [hidden] { display: none !important; }
-      body {
-        margin: 0;
-        background: var(--bg);
-        color: var(--text);
-        font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
-      }
-      .container {
-        width: 100%;
-        max-width: 980px;
-        margin: 32px auto;
-        padding: 0 16px;
-      }
-      h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: .2px; }
-      .subtitle { color: var(--muted); margin: 0; }
-
-      .card {
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 16px;
-        box-shadow: 0 10px 30px rgba(0,0,0,.15);
-        padding: 20px;
-      }
-
-      .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
-      .field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
-      .field.full { grid-column: 1 / -1; }
-      label { color: var(--muted); font-size: 14px; }
-      select, input[type="file"], input[type="password"] {
-        padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border);
-        background: transparent; color: var(--text);
-      }
-      small { color: var(--muted); }
-
-      .actions { grid-column: 1 / -1; display: flex; gap: 10px; margin-top: 8px; }
-
-      button, .button {
-        display: inline-flex; align-items: center; justify-content: center;
-        padding: 10px 14px; border-radius: 10px; border: 1px solid transparent;
-        background: var(--accent); color: var(--btn-fg); font-weight: 600; cursor: pointer; text-decoration: none;
-      }
-      button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
-      button.danger { background: #e5484d; color: #fff; }
-
-      .status { margin-top: 18px; }
-      .progress-wrap {
-        height: 10px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        overflow: hidden;
-      }
-      .progress {
-        height: 100%; width: 0%;
-        background: linear-gradient(90deg, var(--accent), var(--accent-2));
-        transition: width .25s ease;
-      }
-      .meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
-      .badge {
-        display: inline-block; padding: 4px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        color: var(--text); font-size: 12px;
-      }
-
-      .files-list { margin-top: 14px; display: grid; gap: 10px; }
-      .file-row {
-        display: grid; gap: 8px; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
-      }
-      .file-row .name { font-weight: 600; }
-      .file-row .row-progress { height: 6px; background: transparent; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
-      .file-row .row-progress > div { height:100%; width:0%; background: linear-gradient(90deg, var(--accent-2), var(--accent)); transition: width .25s ease; }
-      .file-row .state { font-size: 12px; color: var(--muted); }
-
-      .logs {
-        margin-top: 16px; max-height: 320px; overflow: auto;
-        background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-        white-space: pre-wrap; word-break: break-word;
-      }
-
-      footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
-
-      /* Bouton thème header */
-      .header-row { display:flex; justify-content: space-between; align-items:center; gap: 12px; }
-      #toggle-theme { min-width: 160px; }
-    </style>
   </head>
   <body>
-    <header class="container">
-      <div class="header-row">
-        <div>
-          <h1>Transcripteur mp3 → txt via Whisper</h1>
-          <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
-        </div>
+    <header>
+      <div class="container header-row">
+        <img id="logo" src="/static/logo.png" alt="Logo" />
         <button id="toggle-theme" type="button">🌙 Mode sombre</button>
       </div>
     </header>
 
     <main class="container card">
+      <h1>Transcripteur mp3 → txt via Whisper</h1>
+      <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
       <form id="form" class="grid">
         <div class="field">
           <label for="mode">Mode de transcription</label>
@@ -182,7 +75,6 @@
         <pre id="logs" class="logs"></pre>
 
         <div id="downloads" class="actions" style="gap:.5rem;" hidden>
-
           <button class="button ghost" id="btn-transcription" onclick="downloadTxt(currentJobId, 'transcription', true)">Télécharger la transcription (TXT)</button>
           <button class="button ghost" id="btn-summary" style="display:none;" onclick="downloadTxt(currentJobId, 'summary', true)">Télécharger le résumé (TXT)</button>
           <button class="button" id="btn-zip" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>


### PR DESCRIPTION
## Summary
- implement light and dark color themes with gradient backgrounds
- add glass panel styling and accessible focus/hover states
- switch logo and theme based on system preference and localStorage

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68adb7c065448333ae174d740c85c9fc