### PR TITLE
feat: add light and dark theme with system preference

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,7 @@ const downloadWrap = document.getElementById("downloads");
 const summaryBtn = document.getElementById("btn-summary");
 
 const themeBtn = document.getElementById("toggle-theme");
+const logo = document.getElementById("logo");
 
 // Masquer les boutons de téléchargement tant que la transcription n'est pas terminée
 downloadWrap.hidden = true;
@@ -34,27 +35,36 @@ let isRunning = false;
 
 // ====== Config serveur ======
 (function initConfig() {
-  const node = document.getElementById("whisper-config");
-  const cfg = JSON.parse(node.textContent || "{}");
-  window.MODELS_LOCAL = cfg.MODELS_LOCAL || [];
-  window.MODELS_CLOUD = cfg.MODELS_CLOUD || [];
-  window.LANGS = cfg.LANGS || [];
-  window.DEFAULT_MODEL_LOCAL = cfg.DEFAULT_MODEL_LOCAL || (window.MODELS_LOCAL[0] || "");
-  window.DEFAULT_LANG = cfg.DEFAULT_LANG || (window.LANGS[0] || "fr");
+  try {
+    const node = document.getElementById("whisper-config");
+    const cfg = JSON.parse(node?.textContent || "{}");
+    window.MODELS_LOCAL = cfg.MODELS_LOCAL || [];
+    window.MODELS_CLOUD = cfg.MODELS_CLOUD || [];
+    window.LANGS = cfg.LANGS || [];
+    window.DEFAULT_MODEL_LOCAL = cfg.DEFAULT_MODEL_LOCAL || (window.MODELS_LOCAL[0] || "");
+    window.DEFAULT_LANG = cfg.DEFAULT_LANG || (window.LANGS[0] || "fr");
+  } catch (err) {
+    console.error("Config init failed", err);
+  }
 })();
 
 // ====== Thème (persistance localStorage) ======
 (function initTheme() {
   const root = document.documentElement;
-  const saved = localStorage.getItem("theme") || "light";
-  root.setAttribute("data-theme", saved);
-  themeBtn.textContent = saved === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  if (!themeBtn) return;
+  const saved = localStorage.getItem("theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const current = saved || (prefersDark ? "dark" : "light");
+  root.setAttribute("data-theme", current);
+  themeBtn.textContent = current === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  if (logo) logo.src = current === "dark" ? "/static/logo_white.png" : "/static/logo.png";
 
   themeBtn.addEventListener("click", () => {
     const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
     root.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
     themeBtn.textContent = next === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+    if (logo) logo.src = next === "dark" ? "/static/logo_white.png" : "/static/logo.png";
   });
 })();
 
@@ -72,8 +82,8 @@ function fillModelOptions() {
     modelSelect.appendChild(opt);
   });
 
-  apiKeyWrap.style.display = useAPI ? "flex" : "none";
-  outputTypeWrap.style.display = useAPI ? "flex" : "none";
+  apiKeyWrap.hidden = !useAPI;
+  outputTypeWrap.hidden = !useAPI;
 }
 function fillLangOptions() {
   langSelect.innerHTML = "";
@@ -154,7 +164,7 @@ async function pollStatus() {
 
     // Assurer l'affichage correct des boutons selon l'état et le mode
     downloadWrap.hidden = job.status !== "done";
-    summaryBtn.style.display = job.use_api ? "inline-flex" : "none";
+    summaryBtn.hidden = !job.use_api;
 
     if (Array.isArray(job.logs)) {
       const slice = job.logs.slice(lastLogLength).join("\n");
@@ -232,7 +242,7 @@ form.addEventListener("submit", async (e) => {
 
   const fd = new FormData();
   const use_api = modeSelect.value === "api";
-  summaryBtn.style.display = use_api ? "inline-flex" : "none";
+  summaryBtn.hidden = !use_api;
   fd.append("use_api", use_api ? "1" : "0");
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
@@ -276,7 +286,7 @@ resetBtn.addEventListener("click", () => {
   filesList.innerHTML = "";
   progressBar.style.width = "0%";
   downloadWrap.hidden = true;
-  summaryBtn.style.display = "none";
+  summaryBtn.hidden = true;
 
 
   // Remettre les options par défaut

--- a/static/style.css
+++ b/static/style.css
@@ -1,29 +1,76 @@
 :root {
-  --bg: #0f1115;
-  --card: #151821;
-  --text: #e6e7ee;
-  --muted: #9aa0aa;
-  --accent: #6ea8fe;
-  --accent-2: #84e1bc;
-  --border: #2a2f3a;
-  --shadow: 0 10px 30px rgba(0,0,0,0.35);
-  --radius: 16px;
+  --accent: #4F46E5;
+  --accent-hover: #6366F1;
+  --accent-2: #22D3EE;
 }
 
-* { box-sizing: border-box; }
+html[data-theme='dark'] {
+  --bg-base: #0b1020;
+  --bg-radial: radial-gradient(circle at top, #0f172a, #0b1020);
+  --bg-linear: linear-gradient(145deg, rgba(31,42,68,0.4), rgba(16,52,74,0.4));
+  --text: #E6ECF2;
+  --muted: #AAB4C0;
+  --panel-bg: rgba(18,24,38,0.55);
+  --panel-border: rgba(255,255,255,0.08);
+  --panel-shadow: 0 20px 60px rgba(0,0,0,0.45);
+}
+
+html[data-theme='light'] {
+  --bg-base: #EAF0FF;
+  --bg-radial: radial-gradient(circle at top, #F4F7FF, #EAF0FF);
+  --bg-linear: linear-gradient(145deg, rgba(234,242,255,0.6), rgba(230,246,255,0.6));
+  --text: #0B1220;
+  --muted: #4B5563;
+  --panel-bg: rgba(255,255,255,0.65);
+  --panel-border: rgba(15,23,42,0.10);
+  --panel-shadow: 0 16px 50px rgba(16,24,40,0.15);
+}
+
+*,*::before,*::after { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
   margin: 0;
-  background: linear-gradient(180deg, #0f1115, #0b0d12);
+  background-color: var(--bg-base);
+  background-image: var(--bg-linear), var(--bg-radial);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   color: var(--text);
-  font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
 }
+[hidden] { display: none !important; }
 
 .container {
   width: 100%;
   max-width: 980px;
-  margin: 32px auto;
+  margin: 0 auto;
   padding: 0 16px;
+}
+
+.header {
+  height: 72px;
+  display: flex;
+  align-items: center;
+}
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 12px;
+}
+
+#logo {
+  height: 40px;
+}
+
+.card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(16px);
+  padding: 20px;
+  margin-top: 32px;
 }
 
 h1 {
@@ -31,100 +78,119 @@ h1 {
   margin: 0 0 6px;
   letter-spacing: 0.2px;
 }
-.subtitle { color: var(--muted); margin: 0; }
+.subtitle { color: var(--muted); margin: 0 0 16px 0; }
 
-.card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: 20px;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 16px;
-}
-
+.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
 .field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
 .field.full { grid-column: 1 / -1; }
+
 label { color: var(--muted); font-size: 14px; }
 select, input[type="file"], input[type="password"] {
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0f131b;
+  border: 1px solid var(--panel-border);
+  background: transparent;
   color: var(--text);
 }
-small { color: var(--muted); }
 
-.actions {
-  grid-column: 1 / -1;
-  display: flex;
-  gap: 10px;
-  margin-top: 8px;
-}
+.actions { grid-column: 1 / -1; display: flex; gap: 10px; margin-top: 8px; }
+
+#downloads { gap: .5rem; }
 
 button, .button {
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 14px;
   border-radius: 10px;
   border: 1px solid transparent;
   background: var(--accent);
-  color: #0c0e13;
+  color: #fff;
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
-  transition: transform .05s ease;
+  transition: filter .2s ease, box-shadow .2s ease;
 }
+button:hover, .button:hover { background: var(--accent-hover); box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
 button:active { transform: translateY(1px); }
-button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
+button.ghost { background: transparent; border-color: var(--panel-border); color: var(--text); }
+button.danger { background: #e33c3c; color: #fff; border-color: #b92d2d; }
+button.danger:hover { filter: brightness(0.95); box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
 
-/* === bouton "Arrêter" rouge === */
-button.danger {
-  background: #e33c3c;
-  color: #fff;
-  border-color: #b92d2d;
+button:focus-visible,
+.button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
-button.danger:hover { filter: brightness(0.95); }
 
 .status { margin-top: 18px; }
 .progress-wrap {
-  height: 10px; border-radius: 999px; background: #0f131b; border: 1px solid var(--border);
+  height: 10px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
   overflow: hidden;
 }
 .progress {
-  height: 100%; width: 0%;
+  height: 100%;
+  width: 0%;
   background: linear-gradient(90deg, var(--accent), var(--accent-2));
   transition: width .25s ease;
 }
-
 .meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
 .badge {
-  display: inline-block; padding: 4px 8px; border-radius: 999px; background: #1c2230; border: 1px solid var(--border);
-  color: var(--text); font-size: 12px;
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  color: var(--text);
+  font-size: 12px;
 }
 
 .files-list { margin-top: 14px; display: grid; gap: 10px; }
 .file-row {
-  display: grid; gap: 8px;
-  background: #0f131b; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
+  display: grid;
+  gap: 8px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 10px;
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(16px);
 }
 .file-row .name { font-weight: 600; }
-.file-row .row-progress { height: 6px; background:#0b0d12; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
+.file-row .row-progress {
+  height: 6px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
 .file-row .row-progress > div {
-  height:100%; width:0%;
+  height: 100%;
+  width: 0%;
   background: linear-gradient(90deg, var(--accent-2), var(--accent));
   transition: width .25s ease;
 }
 .file-row .state { font-size: 12px; color: var(--muted); }
 
 .logs {
-  margin-top: 16px; max-height: 320px; overflow: auto;
-  background: #0b0d12; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-  white-space: pre-wrap; word-break: break-word;
+  margin-top: 16px;
+  max-height: 320px;
+  overflow: auto;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(16px);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
-.download { margin-top: 16px; }
 footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
+
+#toggle-theme { min-width: 160px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,130 +1,35 @@
 <!doctype html>
-<html lang="fr" data-theme="light">
+<html lang="fr">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Transcripteur Whisper</title>
+    <script>
+      (function () {
+        const saved = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        window.__theme = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', window.__theme);
+      })();
+    </script>
     <link rel="stylesheet" href="/static/style.css" />
     <link rel="icon" href="/static/icon.ico" type="image/x-icon">
-
-    <style>
-      /* Thèmes via variables CSS (persistées avec data-theme sur <html>) */
-      :root[data-theme="dark"] {
-        --bg: #0f1115;
-        --card: #151821;
-        --text: #e6e7ee;
-        --muted: #9aa0aa;
-        --accent: #6ea8fe;
-        --accent-2: #84e1bc;
-        --border: #2a2f3a;
-        --btn-fg: #0c0e13;
-      }
-      :root[data-theme="light"] {
-        --bg: #f6f7fb;
-        --card: #ffffff;
-        --text: #151821;
-        --muted: #5b6472;
-        --accent: #2f6df6;
-        --accent-2: #25b78b;
-        --border: #e4e7ee;
-        --btn-fg: #ffffff;
-      }
-
-      html, body { height: 100%; }
-      [hidden] { display: none !important; }
-      body {
-        margin: 0;
-        background: var(--bg);
-        color: var(--text);
-        font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
-      }
-      .container {
-        width: 100%;
-        max-width: 980px;
-        margin: 32px auto;
-        padding: 0 16px;
-      }
-      h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: .2px; }
-      .subtitle { color: var(--muted); margin: 0; }
-
-      .card {
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 16px;
-        box-shadow: 0 10px 30px rgba(0,0,0,.15);
-        padding: 20px;
-      }
-
-      .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
-      .field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
-      .field.full { grid-column: 1 / -1; }
-      label { color: var(--muted); font-size: 14px; }
-      select, input[type="file"], input[type="password"] {
-        padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border);
-        background: transparent; color: var(--text);
-      }
-      small { color: var(--muted); }
-
-      .actions { grid-column: 1 / -1; display: flex; gap: 10px; margin-top: 8px; }
-
-      button, .button {
-        display: inline-flex; align-items: center; justify-content: center;
-        padding: 10px 14px; border-radius: 10px; border: 1px solid transparent;
-        background: var(--accent); color: var(--btn-fg); font-weight: 600; cursor: pointer; text-decoration: none;
-      }
-      button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
-      button.danger { background: #e5484d; color: #fff; }
-
-      .status { margin-top: 18px; }
-      .progress-wrap {
-        height: 10px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        overflow: hidden;
-      }
-      .progress {
-        height: 100%; width: 0%;
-        background: linear-gradient(90deg, var(--accent), var(--accent-2));
-        transition: width .25s ease;
-      }
-      .meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
-      .badge {
-        display: inline-block; padding: 4px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        color: var(--text); font-size: 12px;
-      }
-
-      .files-list { margin-top: 14px; display: grid; gap: 10px; }
-      .file-row {
-        display: grid; gap: 8px; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
-      }
-      .file-row .name { font-weight: 600; }
-      .file-row .row-progress { height: 6px; background: transparent; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
-      .file-row .row-progress > div { height:100%; width:0%; background: linear-gradient(90deg, var(--accent-2), var(--accent)); transition: width .25s ease; }
-      .file-row .state { font-size: 12px; color: var(--muted); }
-
-      .logs {
-        margin-top: 16px; max-height: 320px; overflow: auto;
-        background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-        white-space: pre-wrap; word-break: break-word;
-      }
-
-      footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
-
-      /* Bouton thème header */
-      .header-row { display:flex; justify-content: space-between; align-items:center; gap: 12px; }
-      #toggle-theme { min-width: 160px; }
-    </style>
   </head>
   <body>
-    <header class="container">
-      <div class="header-row">
-        <div>
-          <h1>Transcripteur mp3 → txt via Whisper</h1>
-          <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
-        </div>
+    <header class="header">
+      <div class="container header-row">
+        <img id="logo" alt="Logo" />
+        <script>
+          document.getElementById('logo').src = window.__theme === 'dark' ? '/static/logo_white.png' : '/static/logo.png';
+        </script>
         <button id="toggle-theme" type="button">🌙 Mode sombre</button>
       </div>
     </header>
 
     <main class="container card">
+      <h1>Transcripteur mp3 → txt via Whisper</h1>
+      <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
+
       <form id="form" class="grid">
         <div class="field">
           <label for="mode">Mode de transcription</label>
@@ -134,12 +39,12 @@
           </select>
         </div>
 
-        <div class="field" id="api-key-wrap" style="display:none">
+        <div class="field" id="api-key-wrap" hidden>
           <label for="api_key">Clé API OpenAI (facultatif si OPENAI_API_KEY est défini)</label>
           <input id="api_key" name="api_key" type="password" placeholder="sk-..." />
         </div>
 
-        <div class="field" id="output-type-wrap" style="display:none">
+        <div class="field" id="output-type-wrap" hidden>
           <label for="output_type">Format de sortie</label>
           <select id="output_type" name="output_type">
             <option value="resume">Résumé</option>
@@ -172,7 +77,9 @@
       </form>
 
       <section id="status" class="status" hidden>
-        <div class="progress-wrap"><div class="progress" id="progress" style="width:0%"></div></div>
+        <div class="progress-wrap">
+          <div class="progress" id="progress"></div>
+        </div>
         <div class="meta">
           <span id="job-id"></span>
           <span id="job-state" class="badge">en attente</span>
@@ -181,10 +88,9 @@
         <div id="files-list" class="files-list"></div>
         <pre id="logs" class="logs"></pre>
 
-        <div id="downloads" class="actions" style="gap:.5rem;" hidden>
-
+        <div id="downloads" class="actions" hidden>
           <button class="button ghost" id="btn-transcription" onclick="downloadTxt(currentJobId, 'transcription', true)">Télécharger la transcription (TXT)</button>
-          <button class="button ghost" id="btn-summary" style="display:none;" onclick="downloadTxt(currentJobId, 'summary', true)">Télécharger le résumé (TXT)</button>
+          <button class="button ghost" id="btn-summary" hidden onclick="downloadTxt(currentJobId, 'summary', true)">Télécharger le résumé (TXT)</button>
           <button class="button" id="btn-zip" onclick="downloadZip(currentJobId)">Télécharger en ZIP</button>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- set initial theme and logo before styles load
- remove inline styles and use CSS for layout so gradient shows
- enlarge logo and control visibility via hidden attributes
- fix gradient background variables and ensure theme toggle always works

## Testing
- `python -m py_compile server.py main_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68adb7c065448333ae174d740c85c9fc