### PR TITLE
Add theme-aware header logo

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -22,6 +22,7 @@ const downloadWrap = document.getElementById("downloads");
 const summaryBtn = document.getElementById("btn-summary");
 
 const themeBtn = document.getElementById("toggle-theme");
+const logo = document.getElementById("logo");
 
 // Masquer les boutons de téléchargement tant que la transcription n'est pas terminée
 downloadWrap.hidden = true;
@@ -49,12 +50,14 @@ let isRunning = false;
   const saved = localStorage.getItem("theme") || "light";
   root.setAttribute("data-theme", saved);
   themeBtn.textContent = saved === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  logo.src = saved === "dark" ? "/static/logo_white.png" : "/static/logo.png";
 
   themeBtn.addEventListener("click", () => {
     const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
     root.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
     themeBtn.textContent = next === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+    logo.src = next === "dark" ? "/static/logo_white.png" : "/static/logo.png";
   });
 })();
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,14 +111,19 @@
       /* Bouton thème header */
       .header-row { display:flex; justify-content: space-between; align-items:center; gap: 12px; }
       #toggle-theme { min-width: 160px; }
+      .branding { display:flex; align-items:center; gap: 12px; }
+      .branding img { height:40px; }
     </style>
   </head>
   <body>
     <header class="container">
       <div class="header-row">
-        <div>
-          <h1>Transcripteur mp3 → txt via Whisper</h1>
-          <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
+        <div class="branding">
+          <img id="logo" src="/static/logo.png" alt="Logo" />
+          <div>
+            <h1>Transcripteur mp3 → txt via Whisper</h1>
+            <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
+          </div>
         </div>
         <button id="toggle-theme" type="button">🌙 Mode sombre</button>
       </div>


### PR DESCRIPTION
## Summary
- add branding block with logo in page header
- switch between light and dark logos when theme changes

## Testing
- `python -m py_compile assets/__init__.py main_gui.py server.py`


------
https://chatgpt.com/codex/tasks/task_b_68adc837351c83338bb16d0001b068f6