### PR TITLE
feat: add light and dark theme

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -47,10 +47,10 @@ let isRunning = false;
 // ====== Thème (persistance localStorage) ======
 (function initTheme() {
   const root = document.documentElement;
-  const saved = localStorage.getItem("theme") || "light";
-  root.setAttribute("data-theme", saved);
-  themeBtn.textContent = saved === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
-  if (logoImg) logoImg.src = saved === "dark" ? "/static/logo_white.png" : "/static/logo.png";
+  let current = root.getAttribute("data-theme") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  root.setAttribute("data-theme", current);
+  themeBtn.textContent = current === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  if (logoImg) logoImg.src = current === "dark" ? "/static/logo_white.png" : "/static/logo.png";
 
   themeBtn.addEventListener("click", () => {
     const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";

--- a/static/style.css
+++ b/static/style.css
@@ -1,20 +1,38 @@
-:root {
-  --bg: #0f1115;
-  --card: #151821;
-  --text: #e6e7ee;
-  --muted: #9aa0aa;
-  --accent: #6ea8fe;
-  --accent-2: #84e1bc;
-  --border: #2a2f3a;
-  --shadow: 0 10px 30px rgba(0,0,0,0.35);
-  --radius: 16px;
+:root[data-theme="light"] {
+  --bg-radial: radial-gradient(circle at 50% -20%, #F9FBFF, #EAF4F5);
+  --bg-linear: linear-gradient(#EAF4F5, #DCE5FF);
+  --text: #0B1220;
+  --muted: #4B5563;
+  --panel-bg: rgba(255, 255, 255, 0.65);
+  --panel-border: rgba(15, 23, 42, 0.10);
+  --panel-shadow: 0 16px 50px rgba(16, 24, 40, 0.15);
+  --btn-fg: #FFFFFF;
+  --accent: #0B1C48;
+  --accent-hover: linear-gradient(#0B1C48, #009688);
+  --accent-2: #009688;
+}
+
+:root[data-theme="dark"] {
+  --bg-radial: radial-gradient(circle at 50% -20%, #0B1C48, #102B4A);
+  --bg-linear: linear-gradient(#102B4A, #009688);
+  --text: #E6ECF2;
+  --muted: #AAB4C0;
+  --panel-bg: rgba(18, 24, 38, 0.55);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --panel-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  --btn-fg: #0B1C48;
+  --accent: #22C1C3;
+  --accent-hover: #00796B;
+  --accent-2: #00796B;
 }
 
 * { box-sizing: border-box; }
-html, body { height: 100%; }
+[hidden] { display: none !important; }
+
 body {
   margin: 0;
-  background: linear-gradient(180deg, #0f1115, #0b0d12);
+  min-height: 100vh;
+  background: var(--bg-radial), var(--bg-linear);
   color: var(--text);
   font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
 }
@@ -22,23 +40,54 @@ body {
 .container {
   width: 100%;
   max-width: 980px;
-  margin: 32px auto;
+  margin: 0 auto;
   padding: 0 16px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-top: 40px;
+}
+
+.header-row {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand img {
+  height: 140px;
+  width: auto;
 }
 
 h1 {
   font-size: 28px;
-  margin: 0 0 6px;
-  letter-spacing: 0.2px;
+  margin: 0 0 4px;
+  letter-spacing: .2px;
 }
-.subtitle { color: var(--muted); margin: 0; }
+
+.subtitle {
+  color: var(--muted);
+  margin: 0;
+}
 
 .card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  margin-top: 32px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  box-shadow: var(--panel-shadow);
   padding: 20px;
+  backdrop-filter: blur(16px);
 }
 
 .grid {
@@ -47,16 +96,30 @@ h1 {
   gap: 16px;
 }
 
-.field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
+.field {
+  grid-column: span 6;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .field.full { grid-column: 1 / -1; }
-label { color: var(--muted); font-size: 14px; }
-select, input[type="file"], input[type="password"] {
+
+label {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+select,
+input[type="file"],
+input[type="password"] {
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0f131b;
+  border: 1px solid var(--panel-border);
+  background: transparent;
   color: var(--text);
 }
+
 small { color: var(--muted); }
 
 .actions {
@@ -66,65 +129,136 @@ small { color: var(--muted); }
   margin-top: 8px;
 }
 
-button, .button {
-  display: inline-flex; align-items: center; justify-content: center;
+button,
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 14px;
   border-radius: 10px;
   border: 1px solid transparent;
   background: var(--accent);
-  color: #0c0e13;
+  color: var(--btn-fg);
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
-  transition: transform .05s ease;
+  transition: background .2s ease, box-shadow .2s ease;
 }
-button:active { transform: translateY(1px); }
-button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
 
-/* === bouton "Arrêter" rouge === */
+button:hover,
+.button:hover {
+  background: var(--accent-hover);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+button:active { transform: translateY(1px); }
+
+button.ghost {
+  background: transparent;
+  border-color: var(--panel-border);
+  color: var(--text);
+}
+
 button.danger {
   background: #e33c3c;
   color: #fff;
   border-color: #b92d2d;
 }
-button.danger:hover { filter: brightness(0.95); }
 
 .status { margin-top: 18px; }
+
 .progress-wrap {
-  height: 10px; border-radius: 999px; background: #0f131b; border: 1px solid var(--border);
+  height: 10px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
   overflow: hidden;
 }
+
 .progress {
-  height: 100%; width: 0%;
+  height: 100%;
+  width: 0%;
   background: linear-gradient(90deg, var(--accent), var(--accent-2));
   transition: width .25s ease;
 }
 
-.meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
-.badge {
-  display: inline-block; padding: 4px 8px; border-radius: 999px; background: #1c2230; border: 1px solid var(--border);
-  color: var(--text); font-size: 12px;
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  color: var(--muted);
 }
 
-.files-list { margin-top: 14px; display: grid; gap: 10px; }
-.file-row {
-  display: grid; gap: 8px;
-  background: #0f131b; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
+.badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  color: var(--text);
+  font-size: 12px;
 }
+
+.files-list {
+  margin-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.file-row {
+  display: grid;
+  gap: 8px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 10px;
+}
+
 .file-row .name { font-weight: 600; }
-.file-row .row-progress { height: 6px; background:#0b0d12; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
+
+.file-row .row-progress {
+  height: 6px;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
 .file-row .row-progress > div {
-  height:100%; width:0%;
+  height: 100%;
+  width: 0%;
   background: linear-gradient(90deg, var(--accent-2), var(--accent));
   transition: width .25s ease;
 }
-.file-row .state { font-size: 12px; color: var(--muted); }
 
-.logs {
-  margin-top: 16px; max-height: 320px; overflow: auto;
-  background: #0b0d12; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-  white-space: pre-wrap; word-break: break-word;
+.file-row .state {
+  font-size: 12px;
+  color: var(--muted);
 }
 
-.download { margin-top: 16px; }
-footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
+.logs {
+  margin-top: 16px;
+  max-height: 320px;
+  overflow: auto;
+  background: transparent;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+footer.muted {
+  color: var(--muted);
+  text-align: center;
+  margin: 24px 0;
+}
+
+#toggle-theme { min-width: 160px; }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,125 +1,21 @@
 <!doctype html>
-<html lang="fr" data-theme="light">
+<html lang="fr">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Transcripteur Whisper</title>
+    <script>
+      (function(){
+        const saved = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', saved);
+      })();
+    </script>
     <link rel="stylesheet" href="/static/style.css" />
     <link rel="icon" href="/static/icon.ico" type="image/x-icon">
-
-    <style>
-      /* Thèmes via variables CSS (persistées avec data-theme sur <html>) */
-      :root[data-theme="dark"] {
-        --bg: #0f1115;
-        --card: #151821;
-        --text: #e6e7ee;
-        --muted: #9aa0aa;
-        --accent: #6ea8fe;
-        --accent-2: #84e1bc;
-        --border: #2a2f3a;
-        --btn-fg: #0c0e13;
-      }
-      :root[data-theme="light"] {
-        --bg: #f6f7fb;
-        --card: #ffffff;
-        --text: #151821;
-        --muted: #5b6472;
-        --accent: #2f6df6;
-        --accent-2: #25b78b;
-        --border: #e4e7ee;
-        --btn-fg: #ffffff;
-      }
-
-      html, body { height: 100%; }
-      [hidden] { display: none !important; }
-      body {
-        margin: 0;
-        background: var(--bg);
-        color: var(--text);
-        font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
-      }
-      .container {
-        width: 100%;
-        max-width: 980px;
-        margin: 32px auto;
-        padding: 0 16px;
-      }
-      h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: .2px; }
-      .subtitle { color: var(--muted); margin: 0; }
-
-      .card {
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 16px;
-        box-shadow: 0 10px 30px rgba(0,0,0,.15);
-        padding: 20px;
-      }
-
-      .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
-      .field { grid-column: span 6; display: flex; flex-direction: column; gap: 6px; }
-      .field.full { grid-column: 1 / -1; }
-      label { color: var(--muted); font-size: 14px; }
-      select, input[type="file"], input[type="password"] {
-        padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border);
-        background: transparent; color: var(--text);
-      }
-      small { color: var(--muted); }
-
-      .actions { grid-column: 1 / -1; display: flex; gap: 10px; margin-top: 8px; }
-
-      button, .button {
-        display: inline-flex; align-items: center; justify-content: center;
-        padding: 10px 14px; border-radius: 10px; border: 1px solid transparent;
-        background: var(--accent); color: var(--btn-fg); font-weight: 600; cursor: pointer; text-decoration: none;
-      }
-      button.ghost { background: transparent; border-color: var(--border); color: var(--text); }
-      button.danger { background: #e5484d; color: #fff; }
-
-      .status { margin-top: 18px; }
-      .progress-wrap {
-        height: 10px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        overflow: hidden;
-      }
-      .progress {
-        height: 100%; width: 0%;
-        background: linear-gradient(90deg, var(--accent), var(--accent-2));
-        transition: width .25s ease;
-      }
-      .meta { display: flex; justify-content: space-between; align-items: center; margin-top: 8px; color: var(--muted); }
-      .badge {
-        display: inline-block; padding: 4px 8px; border-radius: 999px; background: transparent; border: 1px solid var(--border);
-        color: var(--text); font-size: 12px;
-      }
-
-      .files-list { margin-top: 14px; display: grid; gap: 10px; }
-      .file-row {
-        display: grid; gap: 8px; background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 10px;
-      }
-      .file-row .name { font-weight: 600; }
-      .file-row .row-progress { height: 6px; background: transparent; border:1px solid var(--border); border-radius:999px; overflow:hidden; }
-      .file-row .row-progress > div { height:100%; width:0%; background: linear-gradient(90deg, var(--accent-2), var(--accent)); transition: width .25s ease; }
-      .file-row .state { font-size: 12px; color: var(--muted); }
-
-      .logs {
-        margin-top: 16px; max-height: 320px; overflow: auto;
-        background: transparent; border: 1px solid var(--border); border-radius: 12px; padding: 12px;
-        white-space: pre-wrap; word-break: break-word;
-      }
-
-      footer.muted { color: var(--muted); text-align: center; margin-bottom: 24px; }
-
-      /* Bouton thème header */
-      .header-row { display:flex; justify-content: space-between; align-items:center; gap: 12px; }
-      #toggle-theme { min-width: 160px; }
-
-      .brand { display:flex; align-items:center; gap:24px; }
-      .brand img { height:150px; }
-      :root[data-theme="dark"] .brand img { content:url('/static/logo_white.png'); }
-    </style>
   </head>
   <body>
-    <header class="container">
-      <div class="header-row">
+    <header class="header">
+      <div class="container header-row">
         <div class="brand">
           <img id="logo" src="/static/logo.png" alt="Logo" />
           <div>
@@ -197,7 +93,7 @@
       </section>
     </main>
 
-    <footer class="container muted">
+    <footer class="muted">
       Whisper + VAD Silero · API OpenAI optionnelle · Fait par Romain Cieslik
     </footer>
 


### PR DESCRIPTION
## Summary
- add theme variables for light and dark modes with glass panel styling
- update layout to use new header, theme toggle, and logo assets
- respect system color scheme and persist user choice
- refine color palette, enlarge header logo, and center footer text

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68add2afd0a88333bd858c1c86859a44