### PR TITLE
Animate background during transcription

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -23,6 +23,7 @@ const summaryBtn = document.getElementById("btn-summary");
 
 const themeBtn = document.getElementById("toggle-theme");
 const logoImg = document.getElementById("logo");
+const bodyEl = document.body;
 
 // Masquer les boutons de téléchargement tant que la transcription n'est pas terminée
 downloadWrap.hidden = true;
@@ -32,6 +33,10 @@ let pollTimer = null;
 let currentJobId = null;
 let lastLogLength = 0;
 let isRunning = false;
+
+function setTranscribing(active) {
+  bodyEl.classList.toggle('transcribing', !!active);
+}
 
 // ====== Config serveur ======
 (function initConfig() {
@@ -172,6 +177,7 @@ async function pollStatus() {
       progressBar.style.width = "100%";
       clearInterval(pollTimer); pollTimer = null;
       isRunning = false;
+      setTranscribing(false);
       startBtn.disabled = false;
       startBtn.textContent = "Lancer la transcription";
       startBtn.classList.remove("danger");
@@ -183,6 +189,7 @@ async function pollStatus() {
     console.error(err);
     clearInterval(pollTimer); pollTimer = null;
     isRunning = false;
+    setTranscribing(false);
     startBtn.disabled = false;
     startBtn.textContent = "Lancer la transcription";
     startBtn.classList.remove("danger");
@@ -204,6 +211,7 @@ form.addEventListener("submit", async (e) => {
     // petit délai visuel pour que l'utilisateur voie l'état
     setTimeout(() => {
       isRunning = false;
+      setTranscribing(false);
       startBtn.disabled = false;
       startBtn.textContent = "Lancer la transcription";
       startBtn.classList.remove("danger");
@@ -221,6 +229,7 @@ form.addEventListener("submit", async (e) => {
 
   // lock UI + reset affichages
   isRunning = true;
+  setTranscribing(true);
   startBtn.textContent = "Arrêter la transcription";
   startBtn.classList.add("danger");
   startBtn.disabled = true;      // on le réactive dès que le job démarre
@@ -258,6 +267,7 @@ form.addEventListener("submit", async (e) => {
     console.error(err);
     alert("Erreur au lancement : " + err.message);
     isRunning = false;
+    setTranscribing(false);
     startBtn.disabled = false;
     startBtn.textContent = "Lancer la transcription";
     startBtn.classList.remove("danger");
@@ -271,6 +281,7 @@ resetBtn.addEventListener("click", () => {
   currentJobId = null;
   lastLogLength = 0;
   isRunning = false;
+  setTranscribing(false);
 
   // reset visuel du formulaire
   form.reset();

--- a/static/style.css
+++ b/static/style.css
@@ -262,3 +262,20 @@ footer.muted {
   outline-offset: 2px;
 }
 
+body.transcribing {
+  background-size: 300% 300%;
+  animation: bg-pan 12s ease infinite;
+}
+
+@keyframes bg-pan {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+


### PR DESCRIPTION
## Summary
- animate page background while transcription job runs
- toggle background animation by tracking transcription state in the UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af0bbf891883338cfbe91822b26036