### PR TITLE
Shrink theme toggle icon

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -49,14 +49,14 @@ let isRunning = false;
   const root = document.documentElement;
   let current = root.getAttribute("data-theme") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
   root.setAttribute("data-theme", current);
-  themeBtn.textContent = current === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+  themeBtn.textContent = current === "dark" ? "☀️" : "🌙";
   if (logoImg) logoImg.src = current === "dark" ? "/static/logo_white.png" : "/static/logo.png";
 
   themeBtn.addEventListener("click", () => {
     const next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
     root.setAttribute("data-theme", next);
     localStorage.setItem("theme", next);
-    themeBtn.textContent = next === "dark" ? "☀️ Mode clair" : "🌙 Mode sombre";
+    themeBtn.textContent = next === "dark" ? "☀️" : "🌙";
     if (logoImg) logoImg.src = next === "dark" ? "/static/logo_white.png" : "/static/logo.png";
   });
 })();

--- a/static/style.css
+++ b/static/style.css
@@ -255,7 +255,12 @@ footer.muted {
   margin: 24px 0;
 }
 
-#toggle-theme { min-width: 160px; }
+#toggle-theme {
+  width: 40px;
+  height: 40px;
+  min-width: 0;
+  padding: 0;
+}
 
 :focus-visible {
   outline: 2px solid var(--accent);

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
             <p class="subtitle">Lot de fichiers · Local ou API OpenAI</p>
           </div>
         </div>
-        <button id="toggle-theme" type="button">🌙 Mode sombre</button>
+        <button id="toggle-theme" type="button" aria-label="Basculer le thème">🌙</button>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- Replace dark/light mode button text with a compact icon-only button
- Adjust toggle script to show only sun/moon icons
- Update styles to size the theme toggle button to 40px square

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68af0b76fedc8333acab678e84ce4c5b