### PR TITLE
feat: animate gradient shift during transcription

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -278,32 +278,21 @@ body.transcribing::before {
   left: -150vw;
   width: 400vw;
   height: 400vh;
-  background: var(--bg-radial), var(--bg-linear);
-  animation: bg-rotate 6s linear infinite, bg-pulse 6s ease-in-out infinite;
-  transform-origin: center;
+  background: var(--bg-radial), linear-gradient(120deg, #009688 0%, #22C1C3 50%, #0B1C48 100%);
+  animation: gradient-shift 8s linear infinite;
   z-index: -1;
   pointer-events: none;
-  filter: brightness(1);
 }
 
-@keyframes bg-rotate {
-  from {
-    transform: rotate(0deg);
+@keyframes gradient-shift {
+  0% {
+    background: var(--bg-radial), linear-gradient(120deg, #009688 0%, #22C1C3 50%, #0B1C48 100%);
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    background: var(--bg-radial), linear-gradient(120deg, #0B1C48 0%, #009688 50%, #22C1C3 100%);
   }
-}
-
-@keyframes bg-pulse {
-  0%, 100% {
-    filter: brightness(1);
-  }
-  25% {
-    filter: brightness(var(--pulse-max, 1.3));
-  }
-  75% {
-    filter: brightness(var(--pulse-min, 0.7));
+  100% {
+    background: var(--bg-radial), linear-gradient(120deg, #009688 0%, #22C1C3 50%, #0B1C48 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- animate `body.transcribing::before` with a smooth gradient shift
- define `@keyframes gradient-shift` to cycle through accent colors

## Testing
- `python pretest.py` *(fails: URLError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b584e0a0248333a8228e953f108851