### PR TITLE
feat: add particle background animation

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -52,8 +52,21 @@ let lastLogLength = 0;
 let isRunning = false;
 let totalDurationMin = 0;
 
+let particlesPromise = null;
+function loadParticles() {
+  if (!particlesPromise) {
+    particlesPromise = import("./particles.js").then(() => window.Particles);
+  }
+  return particlesPromise;
+}
+
 function setTranscribing(active) {
   bodyEl.classList.toggle('transcribing', !!active);
+  loadParticles().then(p => {
+    if (!p) return;
+    if (active) p.start();
+    else p.stop();
+  });
 }
 
 // ====== Config serveur ======

--- a/static/particles.js
+++ b/static/particles.js
@@ -1,0 +1,57 @@
+(function(){
+  const canvas = document.getElementById('bg-particles');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const COUNT = 80;
+  let particles = [];
+  let frameId = null;
+
+  function resize(){
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  function createParticles(){
+    particles = Array.from({length: COUNT}, () => ({
+      x: Math.random()*canvas.width,
+      y: Math.random()*canvas.height,
+      vx: (Math.random()-0.5)*0.5,
+      vy: (Math.random()-0.5)*0.5,
+      r: 1 + Math.random()*2
+    }));
+  }
+
+  function step(){
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    particles.forEach(p => {
+      p.x += p.vx;
+      p.y += p.vy;
+      if (p.x < 0 || p.x > canvas.width) p.vx *= -1;
+      if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.r, 0, Math.PI*2);
+      ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      ctx.fill();
+    });
+    frameId = requestAnimationFrame(step);
+  }
+
+  function start(){
+    if (frameId) return;
+    resize();
+    createParticles();
+    step();
+  }
+
+  function stop(){
+    if (frameId) cancelAnimationFrame(frameId);
+    frameId = null;
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+  }
+
+  window.Particles = { start, stop };
+  window.addEventListener('resize', () => {
+    if (!frameId) return; // only resize when running
+    resize();
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -46,6 +46,21 @@ body {
   position: relative;
 }
 
+#bg-particles {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+
+body.transcribing #bg-particles {
+  opacity: 0.5;
+}
+
 .container {
   width: 100%;
   max-width: 980px;
@@ -281,7 +296,7 @@ body.transcribing::before {
   background: var(--bg-radial), var(--bg-linear);
   animation: bg-rotate 6s linear infinite, bg-pulse 6s ease-in-out infinite;
   transform-origin: center;
-  z-index: -1;
+  z-index: -2;
   pointer-events: none;
   filter: brightness(1);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <link rel="icon" href="/static/icon.ico" type="image/x-icon">
   </head>
   <body>
+    <canvas id="bg-particles"></canvas>
     <header class="header">
       <div class="container header-row">
         <div class="brand">


### PR DESCRIPTION
## Summary
- add background canvas for particle effect
- animate particles with new script and wire to transcribing state
- style canvas layering and opacity for background

## Testing
- `python pretest.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b584e1c2d483338e39d5fe7d89b393