### PR TITLE
fix: animate gradient shift during transcription

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -271,39 +271,56 @@ footer.muted {
   outline-offset: 2px;
 }
 
+@property --grad1 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #009688;
+}
+
+@property --grad2 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #22C1C3;
+}
+
+@property --grad3 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #0B1C48;
+}
+
 body.transcribing::before {
+  --grad1: #009688;
+  --grad2: #22C1C3;
+  --grad3: #0B1C48;
   content: "";
   position: fixed;
   top: -150vh;
   left: -150vw;
   width: 400vw;
   height: 400vh;
-  background: var(--bg-radial), var(--bg-linear);
-  animation: bg-rotate 6s linear infinite, bg-pulse 6s ease-in-out infinite;
-  transform-origin: center;
+  background: var(--bg-radial),
+    linear-gradient(120deg, var(--grad1) 0%, var(--grad2) 50%, var(--grad3) 100%);
+  animation: gradient-shift 8s linear infinite;
   z-index: -1;
   pointer-events: none;
-  filter: brightness(1);
 }
 
-@keyframes bg-rotate {
-  from {
-    transform: rotate(0deg);
+@keyframes gradient-shift {
+  0% {
+    --grad1: #009688;
+    --grad2: #22C1C3;
+    --grad3: #0B1C48;
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    --grad1: #0B1C48;
+    --grad2: #009688;
+    --grad3: #22C1C3;
   }
-}
-
-@keyframes bg-pulse {
-  0%, 100% {
-    filter: brightness(1);
-  }
-  25% {
-    filter: brightness(var(--pulse-max, 1.3));
-  }
-  75% {
-    filter: brightness(var(--pulse-min, 0.7));
+  100% {
+    --grad1: #009688;
+    --grad2: #22C1C3;
+    --grad3: #0B1C48;
   }
 }
 


### PR DESCRIPTION
## Summary
- animate `body.transcribing::before` gradient using registered custom color properties
- cycle through accent colors for a visible gradient shift

## Testing
- `python pretest.py` *(fails: URLError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b584e0a0248333a8228e953f108851