### PR TITLE
fix: enable gradient shift during transcription

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -44,6 +44,7 @@ body {
   color: var(--text);
   font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
   position: relative;
+  z-index: 0;
 }
 
 .container {
@@ -271,6 +272,22 @@ footer.muted {
   outline-offset: 2px;
 }
 
+@property --g1 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #009688;
+}
+@property --g2 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #22C1C3;
+}
+@property --g3 {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #0B1C48;
+}
+
 body.transcribing::before {
   content: "";
   position: fixed;
@@ -278,32 +295,31 @@ body.transcribing::before {
   left: -150vw;
   width: 400vw;
   height: 400vh;
-  background: var(--bg-radial), var(--bg-linear);
-  animation: bg-rotate 6s linear infinite, bg-pulse 6s ease-in-out infinite;
-  transform-origin: center;
+  background: var(--bg-radial),
+              linear-gradient(120deg,
+                              var(--g1) 0%,
+                              var(--g2) 50%,
+                              var(--g3) 100%);
+  animation: gradient-shift 8s linear infinite;
   z-index: -1;
   pointer-events: none;
-  filter: brightness(1);
 }
 
-@keyframes bg-rotate {
-  from {
-    transform: rotate(0deg);
+@keyframes gradient-shift {
+  0% {
+    --g1: #009688;
+    --g2: #22C1C3;
+    --g3: #0B1C48;
   }
-  to {
-    transform: rotate(360deg);
+  50% {
+    --g1: #0B1C48;
+    --g2: #009688;
+    --g3: #22C1C3;
   }
-}
-
-@keyframes bg-pulse {
-  0%, 100% {
-    filter: brightness(1);
-  }
-  25% {
-    filter: brightness(var(--pulse-max, 1.3));
-  }
-  75% {
-    filter: brightness(var(--pulse-min, 0.7));
+  100% {
+    --g1: #009688;
+    --g2: #22C1C3;
+    --g3: #0B1C48;
   }
 }
 


### PR DESCRIPTION
## Summary
- animate gradient colors via custom properties for `body.transcribing::before`
- define `@property` rules and keyframes to cycle accent hues
- ensure body creates stacking context for visible overlay

## Testing
- `python pretest.py` *(fails: URLError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b584e0a0248333a8228e953f108851