### PR TITLE
feat: add animated waveform background

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,3 +1,5 @@
+import { startWaveform, stopWaveform } from "./waveform.js";
+
 // ====== Sélecteurs DOM ======
 const form = document.getElementById("form");
 const modeSelect = document.getElementById("mode");
@@ -54,6 +56,8 @@ let totalDurationMin = 0;
 
 function setTranscribing(active) {
   bodyEl.classList.toggle('transcribing', !!active);
+  if (active) startWaveform();
+  else stopWaveform();
 }
 
 // ====== Config serveur ======

--- a/static/style.css
+++ b/static/style.css
@@ -46,6 +46,17 @@ body {
   position: relative;
 }
 
+#bg-waveform {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.3;
+}
+
 .container {
   width: 100%;
   max-width: 980px;

--- a/static/waveform.js
+++ b/static/waveform.js
@@ -1,0 +1,59 @@
+const canvas = document.getElementById("bg-waveform");
+let ctx = null;
+let animationId = null;
+const BAR_COUNT = 60;
+const SMOOTHING = 0.1;
+const UPDATE_EVERY = 20; // frames
+let samples = new Array(BAR_COUNT).fill(0);
+let targets = new Array(BAR_COUNT).fill(0);
+let frame = 0;
+
+function resize() {
+  if (!canvas) return;
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+function updateSamples() {
+  if (frame % UPDATE_EVERY === 0) {
+    targets = targets.map(() => Math.random());
+  }
+  samples = samples.map((v, i) => v + (targets[i] - v) * SMOOTHING);
+  frame++;
+}
+
+function draw() {
+  if (!ctx) return;
+  resize();
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const color = getComputedStyle(document.documentElement).getPropertyValue("--accent") || "#fff";
+  ctx.fillStyle = color.trim();
+  ctx.globalAlpha = 0.35;
+  const barWidth = canvas.width / BAR_COUNT;
+  updateSamples();
+  samples.forEach((v, i) => {
+    const x = i * barWidth;
+    const h = v * canvas.height;
+    ctx.fillRect(x, canvas.height - h, barWidth * 0.7, h);
+  });
+  animationId = requestAnimationFrame(draw);
+}
+
+export function startWaveform() {
+  if (!canvas) return;
+  ctx = canvas.getContext("2d");
+  if (animationId) cancelAnimationFrame(animationId);
+  samples.fill(0);
+  targets.fill(0);
+  frame = 0;
+  draw();
+}
+
+export function stopWaveform() {
+  if (animationId) cancelAnimationFrame(animationId);
+  animationId = null;
+  if (ctx && canvas) ctx.clearRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener("resize", resize);
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <link rel="icon" href="/static/icon.ico" type="image/x-icon">
   </head>
   <body>
+    <canvas id="bg-waveform"></canvas>
     <header class="header">
       <div class="container header-row">
         <div class="brand">
@@ -112,6 +113,6 @@
       } | tojson }}
     </script>
 
-    <script src="/static/app.js" defer></script>
+    <script type="module" src="/static/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add fullscreen canvas for waveform visualization
- animate waveform with smoother, slower bar transitions tied to transcription state
- style canvas backdrop for transparency

## Testing
- `pytest`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b584def7f88333a85df0b400748b70