### PR TITLE
feat: add default transcription-only API output

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -23,6 +23,7 @@ const summaryBtn = document.getElementById("btn-summary");
 const estimateNode = document.getElementById("estimate");
 
 const OUTPUT_LABELS = {
+  transcription: "Télécharger la transcription (TXT)",
   resume: "Télécharger le résumé (TXT)",
   compte_rendu: "Télécharger le compte rendu (TXT)",
   note_de_cadrage: "Télécharger la note de cadrage (TXT)",
@@ -40,7 +41,11 @@ const bodyEl = document.body;
 downloadWrap.hidden = true;
 
 function updateSummaryBtnLabel() {
-  summaryBtn.textContent = OUTPUT_LABELS[outputTypeSelect.value] || "Télécharger le document (TXT)";
+  const show = modeSelect.value === "api" && outputTypeSelect.value !== "transcription";
+  summaryBtn.style.display = show ? "inline-flex" : "none";
+  if (show) {
+    summaryBtn.textContent = OUTPUT_LABELS[outputTypeSelect.value] || "Télécharger le document (TXT)";
+  }
 }
 outputTypeSelect.addEventListener("change", updateSummaryBtnLabel);
 updateSummaryBtnLabel();
@@ -243,8 +248,9 @@ async function pollStatus() {
 
     // Assurer l'affichage correct des boutons selon l'état et le mode
     downloadWrap.hidden = job.status !== "done";
-    summaryBtn.style.display = job.use_api ? "inline-flex" : "none";
-    if (job.use_api) {
+    const showSummary = job.use_api && job.output_type && job.output_type !== "transcription";
+    summaryBtn.style.display = showSummary ? "inline-flex" : "none";
+    if (showSummary) {
       summaryBtn.textContent = OUTPUT_LABELS[job.output_type] || "Télécharger le document (TXT)";
     }
 
@@ -328,8 +334,7 @@ form.addEventListener("submit", async (e) => {
 
   const fd = new FormData();
   const use_api = modeSelect.value === "api";
-  summaryBtn.style.display = use_api ? "inline-flex" : "none";
-  if (use_api) updateSummaryBtnLabel();
+  updateSummaryBtnLabel();
   fd.append("use_api", use_api ? "1" : "0");
   fd.append("api_key", (apiKeyInput.value || "").trim());
   fd.append("model_label", modelSelect.value);
@@ -391,7 +396,7 @@ resetBtn.addEventListener("click", () => {
 });
 
 // ====== Init ======
-modeSelect.addEventListener("change", () => { fillModelOptions(); updateEstimate(); });
+modeSelect.addEventListener("change", () => { fillModelOptions(); updateEstimate(); updateSummaryBtnLabel(); });
 modelSelect.addEventListener("change", updateEstimate);
 filesInput.addEventListener("change", computeTotalDuration);
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,7 @@
         <div class="field" id="output-type-wrap" style="display:none">
           <label for="output_type">Format de sortie</label>
           <select id="output_type" name="output_type">
+            <option value="transcription" selected>Transcription uniquement</option>
             <option value="resume">Résumé</option>
             <option value="compte_rendu">Compte rendu</option>
             <option value="note_de_cadrage">Note de cadrage</option>


### PR DESCRIPTION
## Summary
- default to transcription-only output when using API mode
- skip GPT generation unless a specific document format is requested
- hide summary download button when transcription-only is selected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b55ae0c06c8333b701044366a86d6c