### PR TITLE
Add in-app audio recording for microphone and system mix

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,7 @@ const langSelect = document.getElementById("lang");
 const filesInput = document.getElementById("files");
 const startBtn = document.getElementById("start");
 const resetBtn = document.getElementById("reset");
+const recordBtn = document.getElementById("record-btn");
 
 const statusSection = document.getElementById("status");
 const progressBar = document.getElementById("progress");
@@ -63,6 +64,199 @@ function loadParticles() {
     particlesPromise = import("./particles.js").then(() => window.Particles);
   }
   return particlesPromise;
+}
+
+const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+const RECORD_MIME_TYPE = (() => {
+  if (typeof MediaRecorder === "undefined") return "";
+  const preferred = "audio/webm;codecs=opus";
+  if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(preferred)) return preferred;
+  return "";
+})();
+
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingStreams = [];
+let recordingContext = null;
+let recordedFiles = [];
+let recordButtonResetTimer = null;
+
+function setRecordButtonState(state) {
+  if (!recordBtn) return;
+  if (state !== "idle" && recordButtonResetTimer) {
+    clearTimeout(recordButtonResetTimer);
+    recordButtonResetTimer = null;
+  }
+  recordBtn.dataset.state = state;
+  if (state === "recording") {
+    recordBtn.textContent = "⏹️ Arrêter";
+  } else if (state === "preparing") {
+    recordBtn.textContent = "⏳ Préparation…";
+  } else {
+    recordBtn.textContent = "⏺️ Enregistrer";
+  }
+}
+
+function cleanupRecording(stopStreams = false) {
+  if (stopStreams) {
+    recordingStreams.forEach(stream => {
+      stream.getTracks().forEach(track => track.stop());
+    });
+  }
+  recordingStreams = [];
+  if (recordingContext) {
+    recordingContext.close().catch(() => {});
+    recordingContext = null;
+  }
+  mediaRecorder = null;
+  recordingChunks = [];
+}
+
+function allAudioFiles() {
+  const map = new Map();
+  const push = (file) => {
+    if (!file) return;
+    const key = `${file.name}::${file.size}::${file.lastModified}`;
+    map.set(key, file);
+  };
+  Array.from(filesInput.files || []).forEach(push);
+  recordedFiles.forEach(push);
+  return Array.from(map.values());
+}
+
+function syncRecordedFilesToInput() {
+  if (typeof DataTransfer === "undefined") return false;
+  try {
+    const transfer = new DataTransfer();
+    allAudioFiles().forEach(file => transfer.items.add(file));
+    filesInput.files = transfer.files;
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+async function startRecordingCapture() {
+  if (!recordBtn) return;
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia || !navigator.mediaDevices.getDisplayMedia) {
+    alert("L'enregistrement système + micro n'est pas supporté par ce navigateur.");
+    return;
+  }
+  if (!AudioContextClass) {
+    alert("Votre navigateur ne permet pas de mixer les pistes audio nécessaires.");
+    return;
+  }
+
+  recordBtn.disabled = true;
+  setRecordButtonState("preparing");
+
+  let micStream = null;
+  let systemStream = null;
+
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 2,
+        echoCancellation: false,
+        noiseSuppression: false,
+      },
+      video: false,
+    });
+
+    systemStream = await navigator.mediaDevices.getDisplayMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+      },
+      video: { frameRate: 5 },
+    });
+
+    systemStream.getVideoTracks().forEach(track => {
+      track.enabled = false;
+    });
+
+    const sysAudioTracks = systemStream.getAudioTracks();
+    if (!sysAudioTracks.length) {
+      throw new Error("Aucun son système n'a été partagé.");
+    }
+
+    const audioCtx = new AudioContextClass();
+    const destination = audioCtx.createMediaStreamDestination();
+
+    const micSource = audioCtx.createMediaStreamSource(micStream);
+    micSource.connect(destination);
+
+    const systemAudioStream = new MediaStream(sysAudioTracks);
+    const sysSource = audioCtx.createMediaStreamSource(systemAudioStream);
+    sysSource.connect(destination);
+
+    recordingStreams = [micStream, systemStream, systemAudioStream];
+    recordingContext = audioCtx;
+    recordingChunks = [];
+
+    const options = RECORD_MIME_TYPE ? { mimeType: RECORD_MIME_TYPE } : undefined;
+    mediaRecorder = new MediaRecorder(destination.stream, options);
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size) recordingChunks.push(event.data);
+    };
+    mediaRecorder.onstop = () => {
+      const mime = RECORD_MIME_TYPE || (mediaRecorder ? mediaRecorder.mimeType : "audio/webm");
+      const blob = new Blob(recordingChunks, { type: mime || "audio/webm" });
+      cleanupRecording(true);
+
+      if (!blob.size) {
+        setRecordButtonState("idle");
+        recordBtn.disabled = false;
+        alert("Aucun audio n'a été capturé.");
+        return;
+      }
+
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const fileName = `enregistrement_${stamp}.webm`;
+      const file = new File([blob], fileName, { type: blob.type, lastModified: Date.now() });
+      recordedFiles.push(file);
+
+      const synced = syncRecordedFilesToInput();
+      if (synced) {
+        recordBtn.title = "Enregistrer";
+      } else {
+        recordBtn.title = "Le fichier a été ajouté pour l'envoi, mais il peut ne pas apparaître dans la liste.";
+        alert("L'enregistrement est prêt et sera envoyé automatiquement, même s'il n'apparaît pas dans la liste des fichiers.");
+      }
+
+      const changeEvent = new Event("change", { bubbles: true });
+      filesInput.dispatchEvent(changeEvent);
+
+      setRecordButtonState("idle");
+      recordBtn.textContent = "✅ Ajouté";
+      recordBtn.disabled = false;
+      if (recordButtonResetTimer) clearTimeout(recordButtonResetTimer);
+      recordButtonResetTimer = setTimeout(() => {
+        recordButtonResetTimer = null;
+        setRecordButtonState("idle");
+      }, 2000);
+    };
+
+    mediaRecorder.start();
+    setRecordButtonState("recording");
+  } catch (err) {
+    if (micStream) micStream.getTracks().forEach(track => track.stop());
+    if (systemStream) systemStream.getTracks().forEach(track => track.stop());
+    cleanupRecording();
+    setRecordButtonState("idle");
+    alert("Impossible de démarrer l'enregistrement : " + (err && err.message ? err.message : err));
+  } finally {
+    recordBtn.disabled = false;
+  }
+}
+
+function stopRecordingCapture() {
+  if (!mediaRecorder) return;
+  if (mediaRecorder.state !== "inactive") {
+    setRecordButtonState("preparing");
+    recordBtn.disabled = true;
+    mediaRecorder.stop();
+  }
 }
 
 function setTranscribing(active) {
@@ -144,7 +338,7 @@ const API_RATES = {
 };
 
 async function computeTotalDuration() {
-  const files = Array.from(filesInput.files || []);
+  const files = allAudioFiles();
   if (!files.length) {
     totalDurationMin = 0;
     updateEstimate();
@@ -303,6 +497,11 @@ async function pollStatus() {
 form.addEventListener("submit", async (e) => {
   e.preventDefault();
 
+  if (mediaRecorder && mediaRecorder.state === "recording") {
+    alert("Arrête l'enregistrement avant de lancer la transcription.");
+    return;
+  }
+
   // === STOP (UI) ===
   if (isRunning) {
     // on affiche immédiatement l'état "arrêt en cours…"
@@ -325,7 +524,9 @@ form.addEventListener("submit", async (e) => {
   }
 
   // === START ===
-  if (!filesInput.files.length) {
+  const selectedFiles = allAudioFiles();
+
+  if (!selectedFiles.length) {
     alert("Ajoute au moins un fichier audio.");
     return;
   }
@@ -353,7 +554,7 @@ form.addEventListener("submit", async (e) => {
   fd.append("model_label", modelSelect.value);
   fd.append("lang_label", langSelect.value);
   if (use_api) fd.append("output_type", outputTypeSelect.value);
-  Array.from(filesInput.files).forEach(f => fd.append("files", f, f.name));
+  selectedFiles.forEach(f => fd.append("files", f, f.name));
 
 
   try {
@@ -379,6 +580,21 @@ form.addEventListener("submit", async (e) => {
 
 // ====== Réinitialiser (UI only) ======
 resetBtn.addEventListener("click", () => {
+  if (mediaRecorder && mediaRecorder.state === "recording") {
+    stopRecordingCapture();
+  } else {
+    cleanupRecording(true);
+    setRecordButtonState("idle");
+  }
+
+  recordedFiles = [];
+  syncRecordedFilesToInput();
+  recordBtn && (recordBtn.title = "Enregistrer");
+  if (recordButtonResetTimer) {
+    clearTimeout(recordButtonResetTimer);
+    recordButtonResetTimer = null;
+  }
+
   if (pollTimer) clearInterval(pollTimer);
   pollTimer = null;
   currentJobId = null;
@@ -411,8 +627,30 @@ resetBtn.addEventListener("click", () => {
 // ====== Init ======
 modeSelect.addEventListener("change", () => { fillModelOptions(); updateEstimate(); updateSummaryBtnLabel(); });
 modelSelect.addEventListener("change", updateEstimate);
-filesInput.addEventListener("change", computeTotalDuration);
+filesInput.addEventListener("change", () => {
+  if (recordedFiles.length) {
+    syncRecordedFilesToInput();
+  }
+  computeTotalDuration();
+});
 
 fillModelOptions();
 fillLangOptions();
 updateEstimate();
+
+if (recordBtn) {
+  setRecordButtonState("idle");
+
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia || !AudioContextClass) {
+    recordBtn.disabled = true;
+    recordBtn.title = "Votre navigateur ne permet pas cet enregistrement.";
+  } else {
+    recordBtn.addEventListener("click", () => {
+      if (mediaRecorder && mediaRecorder.state === "recording") {
+        stopRecordingCapture();
+      } else {
+        startRecordingCapture();
+      }
+    });
+  }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -122,7 +122,7 @@ h1 {
   gap: 16px;
 }
 
-.field {
+.field { 
   grid-column: span 6;
   display: flex;
   flex-direction: column;
@@ -130,6 +130,13 @@ h1 {
 }
 
 .field.full { grid-column: 1 / -1; }
+
+.field-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
 
 label {
   color: var(--muted);
@@ -189,6 +196,37 @@ button.danger {
   background: #e33c3c;
   color: #fff;
   border-color: #b92d2d;
+}
+
+.record-btn {
+  padding: 6px 10px;
+  font-size: 13px;
+  gap: 6px;
+  background: #c91532;
+  border-color: #9b1128;
+  color: #fff;
+  box-shadow: 0 0 0 0 rgba(201, 21, 50, 0.4);
+  transition: box-shadow .3s ease, background .2s ease;
+}
+
+.record-btn:hover {
+  background: #e11d3f;
+}
+
+.record-btn[data-state="preparing"],
+.record-btn[data-state="recording"] {
+  background: #ff2d55;
+  border-color: #d11439;
+}
+
+.record-btn[data-state="recording"] {
+  animation: pulse-record 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse-record {
+  0% { box-shadow: 0 0 0 0 rgba(255, 45, 85, 0.45); }
+  70% { box-shadow: 0 0 0 12px rgba(255, 45, 85, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 45, 85, 0); }
 }
 
 .status { margin-top: 18px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,10 @@
         </div>
 
         <div class="field full">
-          <label for="files">Fichiers audio</label>
+          <div class="field-label">
+            <label for="files">Fichiers audio</label>
+            <button type="button" id="record-btn" class="record-btn" title="Enregistrer">⏺️ Enregistrer</button>
+          </div>
           <input id="files" name="files" type="file" multiple accept=".mp3,.wav,.m4a,.flac" />
           <small>Formats : mp3, wav, m4a, flac</small>
           <small id="estimate"></small>


### PR DESCRIPTION
## Summary
- add a record control next to the file picker to capture audio directly inside the app
- mix microphone and system audio in the browser, reuse the generated file during transcription, and handle unsupported browsers gracefully
- style the new recording button and keep estimates and resets in sync with recorded files

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68f7458e790083339c2b3e8d66cd343c