### PR TITLE
Add recording button for capturing system and microphone audio

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,8 @@ const langSelect = document.getElementById("lang");
 const filesInput = document.getElementById("files");
 const startBtn = document.getElementById("start");
 const resetBtn = document.getElementById("reset");
+const recordBtn = document.getElementById("record-btn");
+const recordingHint = document.getElementById("recording-hint");
 
 const statusSection = document.getElementById("status");
 const progressBar = document.getElementById("progress");
@@ -57,6 +59,12 @@ let lastLogLength = 0;
 let isRunning = false;
 let totalDurationMin = 0;
 
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingStreams = [];
+let lastRecordedFile = null;
+let isRecording = false;
+
 let particlesPromise = null;
 function loadParticles() {
   if (!particlesPromise) {
@@ -72,6 +80,159 @@ function setTranscribing(active) {
     if (active) p.start();
     else p.stop();
   });
+}
+
+function setRecordButtonState(active) {
+  if (!recordBtn) return;
+  recordBtn.classList.toggle("is-recording", !!active);
+  recordBtn.innerHTML = `<span class="dot" aria-hidden="true"></span>${active ? "Arrêter" : "Enregistrer"}`;
+}
+
+function updateRecordingHint(text = "", isError = false) {
+  if (!recordingHint) return;
+  recordingHint.textContent = text;
+  recordingHint.style.color = isError ? "#e33c3c" : "var(--muted)";
+}
+
+function stopRecordingStreams() {
+  recordingStreams.forEach((stream) => {
+    if (!stream) return;
+    stream.getTracks().forEach(track => {
+      try { track.stop(); } catch (_) { /* noop */ }
+    });
+  });
+  recordingStreams = [];
+}
+
+async function startRecording() {
+  if (!recordBtn) return;
+  if (!navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+    updateRecordingHint("Enregistrement non supporté sur ce navigateur.", true);
+    return;
+  }
+
+  recordBtn.disabled = true;
+  updateRecordingHint("Initialisation de l'enregistrement…");
+
+  try {
+    const micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const systemStream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true });
+
+    systemStream.getVideoTracks().forEach(track => { track.enabled = false; });
+
+    const audioTracks = [
+      ...micStream.getAudioTracks(),
+      ...systemStream.getAudioTracks()
+    ].filter(Boolean);
+
+    if (!audioTracks.length) {
+      throw new Error("Aucune piste audio détectée.");
+    }
+
+    const mixedStream = new MediaStream(audioTracks);
+
+    recordingStreams = [micStream, systemStream, mixedStream];
+    recordingChunks = [];
+    mediaRecorder = new MediaRecorder(mixedStream);
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) {
+        recordingChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = finalizeRecording;
+    mediaRecorder.onerror = (event) => {
+      console.error(event.error || event);
+      updateRecordingHint("Erreur d'enregistrement : " + (event.error ? event.error.message : event.message || event.type), true);
+      isRecording = false;
+      setRecordButtonState(false);
+      if (recordBtn) recordBtn.disabled = false;
+      stopRecordingStreams();
+      mediaRecorder = null;
+      recordingChunks = [];
+    };
+
+    mediaRecorder.start();
+    isRecording = true;
+    setRecordButtonState(true);
+    updateRecordingHint("Enregistrement en cours… pensez à partager l'onglet avec le son.");
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Impossible de démarrer : " + (err && err.message ? err.message : err), true);
+    stopRecordingStreams();
+    mediaRecorder = null;
+    recordingChunks = [];
+    isRecording = false;
+    setRecordButtonState(false);
+  } finally {
+    recordBtn.disabled = false;
+  }
+}
+
+function stopRecordingAction() {
+  if (!isRecording || !mediaRecorder) return;
+  recordBtn.disabled = true;
+  updateRecordingHint("Finalisation de l'enregistrement…");
+  try {
+    mediaRecorder.stop();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Arrêt impossible : " + err.message, true);
+    recordBtn.disabled = false;
+  }
+}
+
+function finalizeRecording() {
+  const blob = new Blob(recordingChunks, { type: mediaRecorder && mediaRecorder.mimeType ? mediaRecorder.mimeType : "audio/webm" });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `enregistrement_${timestamp}.webm`;
+  const previousRecordedName = lastRecordedFile ? lastRecordedFile.name : null;
+  const previousRecordedSize = lastRecordedFile ? lastRecordedFile.size : null;
+  const newRecordedFile = new File([blob], filename, { type: blob.type, lastModified: Date.now() });
+  lastRecordedFile = newRecordedFile;
+
+  let dataTransfer;
+  try {
+    dataTransfer = new DataTransfer();
+  } catch (err) {
+    console.error(err);
+  }
+
+  if (!dataTransfer) {
+    updateRecordingHint("Enregistrement prêt mais impossible de l'ajouter automatiquement. Téléchargez-le manuellement.", true);
+    stopRecordingStreams();
+    isRecording = false;
+    setRecordButtonState(false);
+    if (recordBtn) recordBtn.disabled = false;
+    mediaRecorder = null;
+    recordingChunks = [];
+    return;
+  }
+
+  dataTransfer.items.add(newRecordedFile);
+
+  Array.from(filesInput.files || []).forEach((file) => {
+    if (previousRecordedName && file.name === previousRecordedName && file.size === previousRecordedSize) {
+      return;
+    }
+    if (file.name === newRecordedFile.name && file.size === newRecordedFile.size) {
+      return;
+    }
+    dataTransfer.items.add(file);
+  });
+
+  filesInput.files = dataTransfer.files;
+  filesInput.dispatchEvent(new Event("change"));
+
+  updateRecordingHint(`Enregistrement ajouté : ${filename}`);
+
+  isRecording = false;
+  setRecordButtonState(false);
+  if (recordBtn) recordBtn.disabled = false;
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
 }
 
 // ====== Config serveur ======
@@ -386,6 +547,20 @@ resetBtn.addEventListener("click", () => {
   isRunning = false;
   setTranscribing(false);
 
+  if (isRecording && mediaRecorder) {
+    try { mediaRecorder.stop(); } catch (_) { /* noop */ }
+  }
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  isRecording = false;
+  lastRecordedFile = null;
+  setRecordButtonState(false);
+  if (recordBtn) {
+    recordBtn.disabled = false;
+  }
+  updateRecordingHint("");
+
   // reset visuel du formulaire
   form.reset();
   statusSection.hidden = true;
@@ -416,3 +591,14 @@ filesInput.addEventListener("change", computeTotalDuration);
 fillModelOptions();
 fillLangOptions();
 updateEstimate();
+
+if (recordBtn) {
+  setRecordButtonState(false);
+  recordBtn.addEventListener("click", () => {
+    if (isRecording) {
+      stopRecordingAction();
+    } else {
+      startRecording();
+    }
+  });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -131,6 +131,46 @@ h1 {
 
 .field.full { grid-column: 1 / -1; }
 
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.icon-button.record {
+  gap: 6px;
+  background: transparent;
+  border: 1px solid #e33c3c;
+  color: #e33c3c;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.icon-button.record .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #e33c3c;
+  display: inline-block;
+}
+
+.icon-button.record.is-recording,
+.icon-button.record.is-recording:hover {
+  background: #e33c3c;
+  color: #fff;
+  border-color: #b92d2d;
+}
+
+.icon-button.record.is-recording .dot {
+  background: #fff;
+}
+
+.icon-button.record[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 label {
   color: var(--muted);
   font-size: 14px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,9 +68,16 @@
         </div>
 
         <div class="field full">
-          <label for="files">Fichiers audio</label>
+          <div class="field-label-row">
+            <label for="files">Fichiers audio</label>
+            <button id="record-btn" type="button" class="icon-button record">
+              <span class="dot" aria-hidden="true"></span>
+              Enregistrer
+            </button>
+          </div>
           <input id="files" name="files" type="file" multiple accept=".mp3,.wav,.m4a,.flac" />
           <small>Formats : mp3, wav, m4a, flac</small>
+          <small id="recording-hint"></small>
           <small id="estimate"></small>
         </div>
 


### PR DESCRIPTION
## Summary
- add a recording control next to the file picker so users can capture microphone and system audio in-app
- style the new control and status hint to match the interface
- append finished recordings to the upload field for immediate transcription

## Testing
- uvicorn server:app --host 0.0.0.0 --port 8000


------
https://chatgpt.com/codex/tasks/task_b_68f7458e790083339c2b3e8d66cd343c