### PR TITLE
Split OpenAI uploads into 20-minute chunks and add recorder timer

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import io
 import os
 import sys
 import shutil
@@ -6,7 +7,8 @@ import pathlib
 import threading
 import time
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
@@ -28,6 +30,13 @@ try:
     from huggingface_hub import snapshot_download
 except Exception:
     snapshot_download = None  # type: ignore
+
+try:
+    import av  # type: ignore
+    from av.audio.resampler import AudioResampler  # type: ignore
+except Exception:
+    av = None  # type: ignore
+    AudioResampler = None  # type: ignore
 
 
 # ========= Base dir compatible PyInstaller =========
@@ -418,6 +427,146 @@ def run_job(job_id: str, api_key: Optional[str]):
         set_job_status(job_id, "error")
         append_log(job_id, f"[ERREUR JOB] {e}")
 
+# ========= Utilitaires audio (API OpenAI) =========
+
+@dataclass
+class AudioChunk:
+    index: int
+    duration: float
+    name: str
+    path: Optional[str] = None
+    data: Optional[bytes] = None
+
+
+def _ensure_av_available() -> None:
+    if av is None or AudioResampler is None:
+        raise RuntimeError("Le découpage audio nécessite la bibliothèque 'av'.")
+
+
+def _format_seconds(seconds: Optional[float]) -> str:
+    if not seconds or seconds <= 0:
+        return "00:00:00"
+    total = max(0, int(round(seconds)))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def _guess_layout(stream: "av.stream.Stream") -> str:  # type: ignore[name-defined]
+    layout = getattr(stream, "layout", None)
+    if layout is not None:
+        name = getattr(layout, "name", None)
+        if name:
+            return name
+    channels = getattr(stream, "channels", 0) or 1
+    return "mono" if channels == 1 else "stereo"
+
+
+class _ChunkWriter:
+    def __init__(self, rate: int, layout: str):
+        self.rate = rate or 16000
+        self.layout = layout or "mono"
+        self.buffer = io.BytesIO()
+        self.container = av.open(self.buffer, mode="w", format="wav")  # type: ignore[arg-type]
+        self.stream = self.container.add_stream("pcm_s16le", rate=self.rate, layout=self.layout)
+        self.duration = 0.0
+
+    def add_frame(self, frame: "av.AudioFrame") -> None:  # type: ignore[name-defined]
+        sample_rate = frame.sample_rate or self.rate
+        frame_duration = (frame.samples or 0) / float(sample_rate or self.rate or 1)
+        for packet in self.stream.encode(frame):
+            self.container.mux(packet)
+        self.duration += frame_duration
+
+    def finish(self) -> Tuple[bytes, float]:
+        for packet in self.stream.encode(None):
+            self.container.mux(packet)
+        self.container.close()
+        data = self.buffer.getvalue()
+        duration = self.duration
+        self.buffer.close()
+        self.container = None
+        self.stream = None
+        self.buffer = None  # type: ignore[assignment]
+        self.duration = 0.0
+        return data, duration
+
+
+def _split_audio_for_openai(path: str, max_seconds: float = 20 * 60) -> List[AudioChunk]:
+    _ensure_av_available()
+    container = av.open(path)  # type: ignore[arg-type]
+    try:
+        audio_stream = next((s for s in container.streams if s.type == "audio"), None)
+        if audio_stream is None:
+            raise RuntimeError("Aucune piste audio détectée dans le fichier.")
+
+        approx_duration = None
+        if audio_stream.duration and audio_stream.time_base:
+            try:
+                approx_duration = float(audio_stream.duration * audio_stream.time_base)
+            except Exception:
+                approx_duration = None
+
+        if approx_duration is not None and approx_duration <= max_seconds + 1e-3:
+            return [
+                AudioChunk(
+                    index=0,
+                    duration=approx_duration,
+                    name=pathlib.Path(path).name,
+                    path=path,
+                )
+            ]
+
+        rate = audio_stream.rate or 16000
+        layout = _guess_layout(audio_stream)
+        resampler = AudioResampler(format="s16", layout=layout, rate=rate)
+
+        chunks: List[AudioChunk] = []
+        chunk_index = 0
+        writer: Optional[_ChunkWriter] = None
+
+        def feed_frames(frames_obj):
+            nonlocal writer, chunk_index
+            if not frames_obj:
+                return
+            frames = frames_obj if isinstance(frames_obj, list) else [frames_obj]
+            for sub in frames:
+                if writer is None:
+                    writer = _ChunkWriter(rate, layout)
+                writer.add_frame(sub)
+                if writer.duration >= max_seconds:
+                    data, duration = writer.finish()
+                    chunk_name = f"{pathlib.Path(path).stem}_part{chunk_index + 1}.wav"
+                    chunks.append(AudioChunk(index=chunk_index, duration=duration, name=chunk_name, data=data))
+                    chunk_index += 1
+                    writer = None
+
+        for frame in container.decode(audio_stream):
+            frame.pts = None
+            feed_frames(resampler.resample(frame))
+
+        feed_frames(resampler.resample(None))
+
+        if writer is not None and writer.duration > 0:
+            data, duration = writer.finish()
+            chunk_name = f"{pathlib.Path(path).stem}_part{chunk_index + 1}.wav"
+            chunks.append(AudioChunk(index=chunk_index, duration=duration, name=chunk_name, data=data))
+
+        if not chunks:
+            return [
+                AudioChunk(
+                    index=0,
+                    duration=approx_duration or 0.0,
+                    name=pathlib.Path(path).name,
+                    path=path,
+                )
+            ]
+
+        return chunks
+    finally:
+        container.close()
+
+
 # ========= OpenAI (cloud) =========
 def _make_openai_client(api_key: Optional[str]):
     if OpenAI is None:
@@ -439,13 +588,51 @@ def _run_cloud(job_id: str, client: "OpenAI"):
         update_file_status(job_id, idx, "running")
         append_log(job_id, f"→ Envoi à OpenAI : {fmeta['name']}")
         try:
-            with open(fmeta["path"], "rb") as fh:
-                resp = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=fh,
-                    language=lang,
+            chunks = _split_audio_for_openai(fmeta["path"])
+            if not chunks:
+                raise RuntimeError("Le fichier audio est vide ou illisible.")
+
+            total_chunks = len(chunks)
+            total_duration = sum(c.duration for c in chunks if c.duration)
+            if total_chunks > 1:
+                append_log(
+                    job_id,
+                    f"   Découpage en {total_chunks} segments ≤ 20 min (durée totale {_format_seconds(total_duration)}).",
                 )
-            text = (getattr(resp, "text", "") or "").strip()
+
+            chunk_texts: List[str] = []
+            for pos, chunk in enumerate(chunks, start=1):
+                if total_chunks > 1:
+                    append_log(
+                        job_id,
+                        f"      · Segment {pos}/{total_chunks} ({_format_seconds(chunk.duration)})",
+                    )
+
+                if chunk.path:
+                    with open(chunk.path, "rb") as fh:
+                        resp = client.audio.transcriptions.create(
+                            model=model_name,
+                            file=fh,
+                            language=lang,
+                        )
+                else:
+                    bio = io.BytesIO(chunk.data or b"")
+                    setattr(bio, "name", chunk.name)
+                    try:
+                        resp = client.audio.transcriptions.create(
+                            model=model_name,
+                            file=bio,
+                            language=lang,
+                        )
+                    finally:
+                        bio.close()
+
+                part_text = (getattr(resp, "text", "") or "").strip()
+                if part_text:
+                    chunk_texts.append(part_text)
+                set_file_progress(job_id, idx, pos / max(total_chunks, 1))
+
+            text = "\n\n".join(t for t in chunk_texts if t).strip()
 
             processed = text
             prompt_tmpl = OUTPUT_PROMPTS.get(output_type)

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,9 @@ const langSelect = document.getElementById("lang");
 const filesInput = document.getElementById("files");
 const startBtn = document.getElementById("start");
 const resetBtn = document.getElementById("reset");
+const recordBtn = document.getElementById("record-btn");
+const recordingHint = document.getElementById("recording-hint");
+const recordTimer = document.getElementById("record-timer");
 
 const statusSection = document.getElementById("status");
 const progressBar = document.getElementById("progress");
@@ -57,6 +60,57 @@ let lastLogLength = 0;
 let isRunning = false;
 let totalDurationMin = 0;
 
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingStreams = [];
+let lastRecordedFile = null;
+let isRecording = false;
+let recordTimerInterval = null;
+let recordStartTime = null;
+
+function formatElapsed(ms) {
+  if (!Number.isFinite(ms)) return "00:00:00";
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
+  const minutes = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, "0");
+  const seconds = String(totalSeconds % 60).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function updateRecordTimerDisplay(text) {
+  if (recordTimer) {
+    recordTimer.textContent = text;
+  }
+}
+
+function resetRecordTimer() {
+  updateRecordTimerDisplay("00:00:00");
+}
+
+function updateRecordTimer() {
+  if (!recordStartTime) return;
+  const now = Date.now();
+  updateRecordTimerDisplay(formatElapsed(now - recordStartTime));
+}
+
+function startRecordTimer() {
+  recordStartTime = Date.now();
+  updateRecordTimer();
+  if (recordTimerInterval) clearInterval(recordTimerInterval);
+  recordTimerInterval = setInterval(updateRecordTimer, 1000);
+}
+
+function stopRecordTimer({ reset = false } = {}) {
+  if (recordTimerInterval) {
+    clearInterval(recordTimerInterval);
+    recordTimerInterval = null;
+  }
+  recordStartTime = null;
+  if (reset) {
+    resetRecordTimer();
+  }
+}
+
 let particlesPromise = null;
 function loadParticles() {
   if (!particlesPromise) {
@@ -72,6 +126,172 @@ function setTranscribing(active) {
     if (active) p.start();
     else p.stop();
   });
+}
+
+function setRecordButtonState(active) {
+  if (!recordBtn) return;
+  recordBtn.classList.toggle("is-recording", !!active);
+  recordBtn.innerHTML = `<span class="dot" aria-hidden="true"></span>${active ? "Arrêter" : "Enregistrer"}`;
+  if (recordTimer) {
+    recordTimer.classList.toggle("is-recording", !!active);
+  }
+}
+
+function updateRecordingHint(text = "", isError = false) {
+  if (!recordingHint) return;
+  recordingHint.textContent = text;
+  recordingHint.style.color = isError ? "#e33c3c" : "var(--muted)";
+}
+
+function stopRecordingStreams() {
+  recordingStreams.forEach((stream) => {
+    if (!stream) return;
+    stream.getTracks().forEach(track => {
+      try { track.stop(); } catch (_) { /* noop */ }
+    });
+  });
+  recordingStreams = [];
+}
+
+async function startRecording() {
+  if (!recordBtn) return;
+  if (!navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+    updateRecordingHint("Enregistrement non supporté sur ce navigateur.", true);
+    return;
+  }
+
+  recordBtn.disabled = true;
+  stopRecordTimer({ reset: true });
+  setRecordButtonState(false);
+  resetRecordTimer();
+  updateRecordingHint("Initialisation de l'enregistrement…");
+
+  try {
+    const micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const systemStream = await navigator.mediaDevices.getDisplayMedia({ audio: true, video: true });
+
+    systemStream.getVideoTracks().forEach(track => { track.enabled = false; });
+
+    const audioTracks = [
+      ...micStream.getAudioTracks(),
+      ...systemStream.getAudioTracks()
+    ].filter(Boolean);
+
+    if (!audioTracks.length) {
+      throw new Error("Aucune piste audio détectée.");
+    }
+
+    const mixedStream = new MediaStream(audioTracks);
+
+    recordingStreams = [micStream, systemStream, mixedStream];
+    recordingChunks = [];
+    mediaRecorder = new MediaRecorder(mixedStream);
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) {
+        recordingChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = finalizeRecording;
+    mediaRecorder.onerror = (event) => {
+      console.error(event.error || event);
+      updateRecordingHint("Erreur d'enregistrement : " + (event.error ? event.error.message : event.message || event.type), true);
+      isRecording = false;
+      setRecordButtonState(false);
+      if (recordBtn) recordBtn.disabled = false;
+      stopRecordingStreams();
+      mediaRecorder = null;
+      recordingChunks = [];
+      stopRecordTimer({ reset: true });
+    };
+
+    mediaRecorder.start();
+    isRecording = true;
+    setRecordButtonState(true);
+    updateRecordingHint("Enregistrement en cours… pensez à partager l'onglet avec le son.");
+    startRecordTimer();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Impossible de démarrer : " + (err && err.message ? err.message : err), true);
+    stopRecordingStreams();
+    mediaRecorder = null;
+    recordingChunks = [];
+    isRecording = false;
+    setRecordButtonState(false);
+    stopRecordTimer({ reset: true });
+  } finally {
+    recordBtn.disabled = false;
+  }
+}
+
+function stopRecordingAction() {
+  if (!isRecording || !mediaRecorder) return;
+  recordBtn.disabled = true;
+  updateRecordingHint("Finalisation de l'enregistrement…");
+  try {
+    mediaRecorder.stop();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Arrêt impossible : " + err.message, true);
+    recordBtn.disabled = false;
+    stopRecordTimer({ reset: true });
+  }
+}
+
+function finalizeRecording() {
+  stopRecordTimer();
+  const blob = new Blob(recordingChunks, { type: mediaRecorder && mediaRecorder.mimeType ? mediaRecorder.mimeType : "audio/webm" });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `enregistrement_${timestamp}.webm`;
+  const previousRecordedName = lastRecordedFile ? lastRecordedFile.name : null;
+  const previousRecordedSize = lastRecordedFile ? lastRecordedFile.size : null;
+  const newRecordedFile = new File([blob], filename, { type: blob.type, lastModified: Date.now() });
+  lastRecordedFile = newRecordedFile;
+
+  let dataTransfer;
+  try {
+    dataTransfer = new DataTransfer();
+  } catch (err) {
+    console.error(err);
+  }
+
+  if (!dataTransfer) {
+    updateRecordingHint("Enregistrement prêt mais impossible de l'ajouter automatiquement. Téléchargez-le manuellement.", true);
+    stopRecordingStreams();
+    isRecording = false;
+    setRecordButtonState(false);
+    if (recordBtn) recordBtn.disabled = false;
+    mediaRecorder = null;
+    recordingChunks = [];
+    stopRecordTimer({ reset: false });
+    return;
+  }
+
+  dataTransfer.items.add(newRecordedFile);
+
+  Array.from(filesInput.files || []).forEach((file) => {
+    if (previousRecordedName && file.name === previousRecordedName && file.size === previousRecordedSize) {
+      return;
+    }
+    if (file.name === newRecordedFile.name && file.size === newRecordedFile.size) {
+      return;
+    }
+    dataTransfer.items.add(file);
+  });
+
+  filesInput.files = dataTransfer.files;
+  filesInput.dispatchEvent(new Event("change"));
+
+  updateRecordingHint(`Enregistrement ajouté : ${filename}`);
+
+  isRecording = false;
+  setRecordButtonState(false);
+  if (recordBtn) recordBtn.disabled = false;
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  stopRecordTimer({ reset: false });
 }
 
 // ====== Config serveur ======
@@ -385,6 +605,21 @@ resetBtn.addEventListener("click", () => {
   lastLogLength = 0;
   isRunning = false;
   setTranscribing(false);
+  stopRecordTimer({ reset: true });
+
+  if (isRecording && mediaRecorder) {
+    try { mediaRecorder.stop(); } catch (_) { /* noop */ }
+  }
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  isRecording = false;
+  lastRecordedFile = null;
+  setRecordButtonState(false);
+  if (recordBtn) {
+    recordBtn.disabled = false;
+  }
+  updateRecordingHint("");
 
   // reset visuel du formulaire
   form.reset();
@@ -416,3 +651,15 @@ filesInput.addEventListener("change", computeTotalDuration);
 fillModelOptions();
 fillLangOptions();
 updateEstimate();
+
+if (recordBtn) {
+  setRecordButtonState(false);
+  resetRecordTimer();
+  recordBtn.addEventListener("click", () => {
+    if (isRecording) {
+      stopRecordingAction();
+    } else {
+      startRecording();
+    }
+  });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -131,6 +131,66 @@ h1 {
 
 .field.full { grid-column: 1 / -1; }
 
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.record-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.record-timer {
+  font-variant-numeric: tabular-nums;
+  font-family: "Roboto Mono", "Fira Mono", "Courier New", monospace;
+  font-size: 14px;
+  color: var(--muted);
+  min-width: 70px;
+  text-align: right;
+}
+
+.record-timer.is-recording {
+  color: #e33c3c;
+  font-weight: 600;
+}
+
+.icon-button.record {
+  gap: 6px;
+  background: transparent;
+  border: 1px solid #e33c3c;
+  color: #e33c3c;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.icon-button.record .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #e33c3c;
+  display: inline-block;
+}
+
+.icon-button.record.is-recording,
+.icon-button.record.is-recording:hover {
+  background: #e33c3c;
+  color: #fff;
+  border-color: #b92d2d;
+}
+
+.icon-button.record.is-recording .dot {
+  background: #fff;
+}
+
+.icon-button.record[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 label {
   color: var(--muted);
   font-size: 14px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,9 +68,19 @@
         </div>
 
         <div class="field full">
-          <label for="files">Fichiers audio</label>
+          <div class="field-label-row">
+            <label for="files">Fichiers audio</label>
+            <div class="record-controls">
+              <span id="record-timer" class="record-timer" aria-live="polite">00:00:00</span>
+              <button id="record-btn" type="button" class="icon-button record">
+                <span class="dot" aria-hidden="true"></span>
+                Enregistrer
+              </button>
+            </div>
+          </div>
           <input id="files" name="files" type="file" multiple accept=".mp3,.wav,.m4a,.flac" />
           <small>Formats : mp3, wav, m4a, flac</small>
+          <small id="recording-hint"></small>
           <small id="estimate"></small>
         </div>
 


### PR DESCRIPTION
## Summary
- chunk OpenAI transcription uploads into segments of at most 20 minutes and merge their results back into single files
- wire the recording workflow to expose an elapsed timer next to the capture button and style the new indicator
- update the UI markup to host the timer while preserving the existing upload control

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_b_68f7458e790083339c2b3e8d66cd343c