### PR TITLE
Improve PC audio capture options

### DIFF
--- a/server.py
+++ b/server.py
@@ -6,13 +6,16 @@ import pathlib
 import threading
 import time
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from pathlib import Path
 
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+
+import av
+from av.audio.resampler import AudioResampler
 
 # ----- LOCAL (faster-whisper)
 from faster_whisper import WhisperModel
@@ -45,6 +48,8 @@ UPLOAD_DIR = BASE_DIR / "uploads"
 TRANS_DIR  = BASE_DIR / "transcriptions"
 TEMP_DIR   = BASE_DIR / "tmp"
 ASSETS_DIR = BASE_DIR / "assets"
+
+MAX_OPENAI_CHUNK_SECONDS = 20 * 60
 
 # Répertoire persistant pour les modèles Whisper.
 # Peut être personnalisé via la variable d'environnement WHISPER_MODELS_DIR.
@@ -427,6 +432,125 @@ def _make_openai_client(api_key: Optional[str]):
         raise RuntimeError("Aucune clé API fournie (champ vide et OPENAI_API_KEY non défini).")
     return OpenAI(api_key=key)
 
+def _format_seconds_hms(seconds: float) -> str:
+    total = max(0, int(round(seconds)))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+def _probe_audio_duration(path: Path) -> Optional[float]:
+    try:
+        with av.open(str(path)) as container:
+            stream = next((s for s in container.streams if s.type == "audio"), None)
+            if stream is None:
+                return None
+            if stream.duration and stream.time_base:
+                return float(stream.duration * stream.time_base)
+            if container.duration:
+                return float(container.duration / av.time_base)
+    except Exception:
+        return None
+    return None
+
+def _split_audio_file(source: Path, chunk_dir: Path, max_seconds: int) -> List[Path]:
+    chunk_paths: List[Path] = []
+    with av.open(str(source)) as container:
+        audio_stream = next((s for s in container.streams if s.type == "audio"), None)
+        if audio_stream is None:
+            raise RuntimeError("Flux audio introuvable")
+
+        rate = audio_stream.rate or getattr(audio_stream.codec_context, "sample_rate", None) or 16000
+        channels = getattr(audio_stream.codec_context, "channels", None) or (
+            audio_stream.layout.channels if getattr(audio_stream, "layout", None) else 1
+        )
+        layout_name = (
+            audio_stream.layout.name
+            if getattr(audio_stream, "layout", None)
+            else ("mono" if channels == 1 else "stereo")
+        )
+
+        resampler = AudioResampler(format="s16", layout=layout_name, rate=rate)
+
+        chunk_index = 0
+        writer = None
+        out_stream = None
+        chunk_path: Optional[Path] = None
+        chunk_time = 0.0
+
+        def open_writer():
+            nonlocal writer, out_stream, chunk_path, chunk_time, chunk_index
+            chunk_path = chunk_dir / f"{source.stem}_part{chunk_index + 1:02d}.wav"
+            writer = av.open(str(chunk_path), "w", format="wav")
+            out_stream = writer.add_stream("pcm_s16le", rate=rate)
+            try:
+                out_stream.layout = layout_name
+            except Exception:
+                out_stream.channels = channels
+            chunk_time = 0.0
+
+        def close_writer():
+            nonlocal writer, out_stream, chunk_index, chunk_path
+            if not writer:
+                return
+            for packet in out_stream.encode(None):
+                writer.mux(packet)
+            writer.close()
+            if chunk_path is not None:
+                chunk_paths.append(chunk_path)
+            writer = None
+            out_stream = None
+            chunk_path = None
+            chunk_index += 1
+
+        for frame in container.decode(audio_stream):
+            if writer is None:
+                open_writer()
+
+            frame_duration = float(frame.samples or 0) / float(frame.sample_rate or rate or 1)
+
+            for resampled in resampler.resample(frame):
+                resampled.pts = None
+                for packet in out_stream.encode(resampled):
+                    writer.mux(packet)
+
+            chunk_time += frame_duration
+
+            if chunk_time >= max_seconds:
+                for resampled in resampler.resample(None):
+                    resampled.pts = None
+                    for packet in out_stream.encode(resampled):
+                        writer.mux(packet)
+                close_writer()
+
+        if writer is not None:
+            for resampled in resampler.resample(None):
+                resampled.pts = None
+                for packet in out_stream.encode(resampled):
+                    writer.mux(packet)
+            close_writer()
+
+    if not chunk_paths:
+        raise RuntimeError("Découpage impossible : sortie vide")
+    return chunk_paths
+
+def _prepare_api_chunks(job_id: str, file_index: int, source_path: Path) -> Tuple[List[Path], Optional[Path], Optional[float], bool]:
+    duration = _probe_audio_duration(source_path)
+    if duration is not None and duration <= MAX_OPENAI_CHUNK_SECONDS + 1:
+        return [source_path], None, duration, False
+
+    chunk_dir = TEMP_DIR / job_id / f"chunks_{file_index:02d}"
+    if chunk_dir.exists():
+        shutil.rmtree(chunk_dir, ignore_errors=True)
+    chunk_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        chunks = _split_audio_file(source_path, chunk_dir, MAX_OPENAI_CHUNK_SECONDS)
+        return chunks, chunk_dir, duration, True
+    except Exception as exc:
+        shutil.rmtree(chunk_dir, ignore_errors=True)
+        append_log(job_id, f"[WARN] Découpage impossible pour {source_path.name} : {exc}. Envoi du fichier complet.")
+        return [source_path], None, duration, False
+
 def _run_cloud(job_id: str, client: "OpenAI"):
     with JOBS_LOCK:
         job = JOBS[job_id]
@@ -438,14 +562,34 @@ def _run_cloud(job_id: str, client: "OpenAI"):
     for idx, fmeta in enumerate(job["files"]):
         update_file_status(job_id, idx, "running")
         append_log(job_id, f"→ Envoi à OpenAI : {fmeta['name']}")
+        cleanup_dir: Optional[Path] = None
         try:
-            with open(fmeta["path"], "rb") as fh:
-                resp = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=fh,
-                    language=lang,
-                )
-            text = (getattr(resp, "text", "") or "").strip()
+            source_path = Path(fmeta["path"])
+            chunk_paths, cleanup_dir, detected_duration, was_split = _prepare_api_chunks(job_id, idx, source_path)
+            if detected_duration is not None:
+                append_log(job_id, f"  · Durée détectée : {_format_seconds_hms(detected_duration)}")
+            if was_split and len(chunk_paths) > 1:
+                append_log(job_id, f"  · Découpe en {len(chunk_paths)} segments de ≤ 20 minutes")
+
+            collected_texts: List[str] = []
+            total_chunks = max(len(chunk_paths), 1)
+            for chunk_pos, chunk_path in enumerate(chunk_paths, start=1):
+                if len(chunk_paths) > 1:
+                    append_log(job_id, f"    Segment {chunk_pos}/{len(chunk_paths)} : {chunk_path.name}")
+                with open(chunk_path, "rb") as fh:
+                    resp = client.audio.transcriptions.create(
+                        model=model_name,
+                        file=fh,
+                        language=lang,
+                    )
+                text_part = (getattr(resp, "text", "") or "").strip()
+                if text_part:
+                    collected_texts.append(text_part)
+
+                set_file_progress(job_id, idx, chunk_pos / total_chunks)
+                set_job_progress(job_id, (idx + (chunk_pos / total_chunks)) / max(total, 1))
+
+            text = "\n\n".join(collected_texts).strip()
 
             processed = text
             prompt_tmpl = OUTPUT_PROMPTS.get(output_type)
@@ -481,6 +625,9 @@ def _run_cloud(job_id: str, client: "OpenAI"):
         except Exception as e:
             update_file_status(job_id, idx, "error", error=str(e))
             append_log(job_id, f"[ERREUR API] {fmeta['name']} : {e}")
+        finally:
+            if cleanup_dir is not None:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
 
         set_job_progress(job_id, (idx + 1) / max(total, 1))
 

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,13 @@ const langSelect = document.getElementById("lang");
 const filesInput = document.getElementById("files");
 const startBtn = document.getElementById("start");
 const resetBtn = document.getElementById("reset");
+const recordBtn = document.getElementById("record-btn");
+const recordingHint = document.getElementById("recording-hint");
+const recordTimer = document.getElementById("record-timer");
+const systemSourceWrap = document.getElementById("system-source-wrap");
+const systemSourceSelect = document.getElementById("system-source");
+const systemSourceStatus = document.getElementById("system-source-status");
+const systemSourceRefreshBtn = document.getElementById("system-source-refresh");
 
 const statusSection = document.getElementById("status");
 const progressBar = document.getElementById("progress");
@@ -37,6 +44,24 @@ const themeBtn = document.getElementById("toggle-theme");
 const logoImg = document.getElementById("logo");
 const bodyEl = document.body;
 
+const SYSTEM_AUDIO_KEYWORDS = [
+  "mix",
+  "stér",
+  "stereo",
+  "système",
+  "system",
+  "pc",
+  "ordinateur",
+  "loopback",
+  "haut-parleur",
+  "haut parleur",
+  "speaker",
+  "what u hear",
+  "output",
+  "internal",
+  "mixage",
+];
+
 // Masquer les boutons de téléchargement tant que la transcription n'est pas terminée
 downloadWrap.hidden = true;
 
@@ -57,6 +82,19 @@ let lastLogLength = 0;
 let isRunning = false;
 let totalDurationMin = 0;
 
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingStreams = [];
+let lastRecordedFile = null;
+let isRecording = false;
+let recordTimerInterval = null;
+let recordStartTime = 0;
+let audioInputs = [];
+let audioContext = null;
+let mixedAudioNodes = [];
+let currentSystemAudioLabel = "";
+let hadSystemAudio = false;
+
 let particlesPromise = null;
 function loadParticles() {
   if (!particlesPromise) {
@@ -72,6 +110,525 @@ function setTranscribing(active) {
     if (active) p.start();
     else p.stop();
   });
+}
+
+function setRecordButtonState(active) {
+  if (!recordBtn) return;
+  recordBtn.classList.toggle("is-recording", !!active);
+  recordBtn.innerHTML = `<span class="dot" aria-hidden="true"></span>${active ? "Arrêter" : "Enregistrer"}`;
+}
+
+function resetRecordTimerDisplay() {
+  if (!recordTimer) return;
+  recordTimer.textContent = "00:00:00";
+  recordTimer.classList.remove("is-recording");
+}
+
+function updateRecordTimerDisplay() {
+  if (!recordTimer) return;
+  const elapsed = Math.max(0, Math.floor((Date.now() - recordStartTime) / 1000));
+  const hours = String(Math.floor(elapsed / 3600)).padStart(2, "0");
+  const minutes = String(Math.floor((elapsed % 3600) / 60)).padStart(2, "0");
+  const seconds = String(elapsed % 60).padStart(2, "0");
+  recordTimer.textContent = `${hours}:${minutes}:${seconds}`;
+}
+
+function startRecordTimer() {
+  if (!recordTimer) return;
+  recordStartTime = Date.now();
+  recordTimer.classList.add("is-recording");
+  updateRecordTimerDisplay();
+  if (recordTimerInterval) clearInterval(recordTimerInterval);
+  recordTimerInterval = setInterval(updateRecordTimerDisplay, 500);
+}
+
+function stopRecordTimer(resetDisplay = false) {
+  if (recordTimerInterval) {
+    clearInterval(recordTimerInterval);
+    recordTimerInterval = null;
+  }
+  if (!recordTimer) return;
+  if (!resetDisplay) {
+    updateRecordTimerDisplay();
+  }
+  recordTimer.classList.remove("is-recording");
+  if (resetDisplay) {
+    recordTimer.textContent = "00:00:00";
+  }
+}
+
+function normalizeLevel(level) {
+  if (level === true) return "error";
+  if (level === false || !level) return "info";
+  if (typeof level === "string") {
+    const lowered = level.toLowerCase();
+    if (["error", "warning", "success", "info"].includes(lowered)) {
+      return lowered;
+    }
+  }
+  return "info";
+}
+
+function updateRecordingHint(text = "", level = "info") {
+  if (!recordingHint) return;
+  const normalized = normalizeLevel(level);
+  recordingHint.textContent = text;
+  recordingHint.classList.remove("is-error", "is-warning", "is-success");
+  if (normalized === "error") {
+    recordingHint.classList.add("is-error");
+  } else if (normalized === "warning") {
+    recordingHint.classList.add("is-warning");
+  } else if (normalized === "success") {
+    recordingHint.classList.add("is-success");
+  }
+}
+
+function setSystemSourceStatus(text = "", level = "info") {
+  if (!systemSourceStatus) return;
+  const normalized = normalizeLevel(level);
+  systemSourceStatus.textContent = text;
+  systemSourceStatus.classList.remove("is-error", "is-warning", "is-success");
+  if (normalized === "error") {
+    systemSourceStatus.classList.add("is-error");
+  } else if (normalized === "warning") {
+    systemSourceStatus.classList.add("is-warning");
+  } else if (normalized === "success") {
+    systemSourceStatus.classList.add("is-success");
+  }
+}
+
+function ensureAudioContext() {
+  if (typeof window === "undefined") return null;
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  if (!Ctx) return null;
+  if (!audioContext || audioContext.state === "closed") {
+    audioContext = new Ctx();
+  }
+  if (audioContext.state === "suspended") {
+    audioContext.resume().catch(() => {});
+  }
+  return audioContext;
+}
+
+function clearMixedAudioNodes() {
+  mixedAudioNodes.forEach(node => {
+    try { node.disconnect(); } catch (_) { /* noop */ }
+  });
+  mixedAudioNodes = [];
+}
+
+function mixStreams(streams) {
+  const ctx = ensureAudioContext();
+  if (!ctx) return null;
+  clearMixedAudioNodes();
+  const destination = ctx.createMediaStreamDestination();
+  streams.forEach(stream => {
+    if (!stream) return;
+    const tracks = stream.getAudioTracks ? stream.getAudioTracks() : [];
+    if (!tracks.length) return;
+    const source = ctx.createMediaStreamSource(new MediaStream(tracks));
+    source.connect(destination);
+    mixedAudioNodes.push(source);
+  });
+  const mixedStream = destination.stream;
+  return mixedStream && mixedStream.getAudioTracks().length ? mixedStream : null;
+}
+
+function stopRecordingStreams() {
+  recordingStreams.forEach((stream) => {
+    if (!stream) return;
+    stream.getTracks().forEach(track => {
+      try { track.stop(); } catch (_) { /* noop */ }
+    });
+  });
+  recordingStreams = [];
+  clearMixedAudioNodes();
+  if (audioContext && audioContext.state === "running") {
+    audioContext.suspend().catch(() => {});
+  }
+  currentSystemAudioLabel = "";
+  hadSystemAudio = false;
+}
+
+function deviceLabelMatchesSystem(label = "") {
+  if (!label) return false;
+  const lower = label.toLowerCase();
+  return SYSTEM_AUDIO_KEYWORDS.some(keyword => lower.includes(keyword));
+}
+
+function detectAutoSystemDevice() {
+  return audioInputs.find(device => deviceLabelMatchesSystem(device.label));
+}
+
+function buildMicConstraints() {
+  return {
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+  };
+}
+
+function buildSystemConstraints(deviceId) {
+  const audio = {
+    echoCancellation: false,
+    noiseSuppression: false,
+    autoGainControl: false,
+    channelCount: 2,
+    sampleRate: 48000,
+  };
+  if (deviceId) {
+    audio.deviceId = { exact: deviceId };
+  }
+  return { audio };
+}
+
+async function refreshSystemDevices() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices || !systemSourceSelect) {
+    return;
+  }
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    audioInputs = devices.filter(d => d && d.kind === "audioinput");
+  } catch (err) {
+    console.error(err);
+    audioInputs = [];
+  }
+
+  const previousValue = systemSourceSelect.value || "auto";
+  systemSourceSelect.innerHTML = "";
+
+  const fragment = document.createDocumentFragment();
+
+  const autoOpt = document.createElement("option");
+  autoOpt.value = "auto";
+  autoOpt.textContent = "Auto (mixage système si disponible)";
+  fragment.appendChild(autoOpt);
+
+  const noneOpt = document.createElement("option");
+  noneOpt.value = "none";
+  noneOpt.textContent = "Aucun (micro uniquement)";
+  fragment.appendChild(noneOpt);
+
+  audioInputs.forEach(device => {
+    const opt = document.createElement("option");
+    opt.value = device.deviceId;
+    opt.textContent = device.label || `Entrée audio (${audioInputs.indexOf(device) + 1})`;
+    fragment.appendChild(opt);
+  });
+
+  if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
+    const screenOpt = document.createElement("option");
+    screenOpt.value = "screen";
+    screenOpt.textContent = "Capture d'écran (audio système)";
+    fragment.appendChild(screenOpt);
+  }
+
+  systemSourceSelect.appendChild(fragment);
+
+  const availableValues = Array.from(systemSourceSelect.options).map(opt => opt.value);
+  if (availableValues.includes(previousValue)) {
+    systemSourceSelect.value = previousValue;
+  } else {
+    systemSourceSelect.value = availableValues.includes("auto") ? "auto" : availableValues[0] || "none";
+  }
+
+  updateSystemSourceSummary();
+}
+
+function updateSystemSourceSummary() {
+  if (!systemSourceSelect) return;
+  const value = systemSourceSelect.value;
+  if (value === "none") {
+    setSystemSourceStatus("Micro uniquement.");
+    return;
+  }
+  if (value === "auto") {
+    const device = detectAutoSystemDevice();
+    if (device) {
+      setSystemSourceStatus(`Auto : ${device.label}`);
+    } else if (audioInputs.length) {
+      setSystemSourceStatus("Auto : aucun mixage système détecté. Sélectionnez un périphérique dans la liste.", "warning");
+    } else {
+      setSystemSourceStatus("Aucun périphérique audio détecté.", "warning");
+    }
+    return;
+  }
+  if (value === "screen") {
+    setSystemSourceStatus("Le navigateur demandera de partager un écran avec l'audio.", "warning");
+    return;
+  }
+  const device = audioInputs.find(d => d.deviceId === value);
+  if (device) {
+    setSystemSourceStatus(`Sélection : ${device.label || "Périphérique audio"}`);
+  } else {
+    setSystemSourceStatus("Périphérique introuvable. Actualisez la liste.", "warning");
+  }
+}
+
+async function tryDirectSystemAudio(micStream) {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return null;
+  const micTrack = micStream && micStream.getAudioTracks ? micStream.getAudioTracks()[0] : null;
+  const micLabel = micTrack ? micTrack.label : "";
+  const micDeviceId = micTrack && micTrack.getSettings ? micTrack.getSettings().deviceId : null;
+  const attempts = [
+    { audio: { captureSystemAudio: true, channelCount: 2, sampleRate: 48000, echoCancellation: false, noiseSuppression: false, autoGainControl: false } },
+    { audio: { systemAudio: "include", channelCount: 2, sampleRate: 48000, echoCancellation: false, noiseSuppression: false, autoGainControl: false } },
+    { audio: { channelCount: 2, sampleRate: 48000, echoCancellation: false, noiseSuppression: false, autoGainControl: false, advanced: [{ systemAudio: "include" }] } },
+  ];
+
+  for (const constraints of attempts) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const tracks = stream.getAudioTracks ? stream.getAudioTracks() : [];
+      if (!tracks.length) {
+        stream.getTracks().forEach(track => track.stop());
+        continue;
+      }
+      const track = tracks[0];
+      const label = track.label || "";
+      const deviceId = track.getSettings ? track.getSettings().deviceId : null;
+      if ((micLabel && label && label === micLabel) || (micDeviceId && deviceId && micDeviceId === deviceId)) {
+        stream.getTracks().forEach(t => t.stop());
+        continue;
+      }
+      if (!deviceLabelMatchesSystem(label)) {
+        // Avoid mistakenly capturing a second microphone.
+        stream.getTracks().forEach(t => t.stop());
+        continue;
+      }
+      return { stream, label: label || "Mixage système" };
+    } catch (err) {
+      // Ignore errors and continue trying other constraints.
+    }
+  }
+  return null;
+}
+
+async function obtainSystemAudioStreamFromSelection() {
+  if (!systemSourceSelect) {
+    return { stream: null, label: "", message: "", level: "info" };
+  }
+
+  const value = systemSourceSelect.value || "auto";
+  if (value === "none") {
+    setSystemSourceStatus("Micro uniquement.");
+    return { stream: null, label: "", message: "Le son du PC est désactivé.", level: "info" };
+  }
+
+  if (!audioInputs.length) {
+    await refreshSystemDevices();
+  }
+
+  if (value === "auto") {
+    const device = detectAutoSystemDevice();
+    if (!device) {
+      const message = "Aucun périphérique de mixage système détecté. Activez \"Stereo Mix\" ou choisissez un périphérique manuel.";
+      setSystemSourceStatus(message, "warning");
+      return { stream: null, label: "", message, level: "warning" };
+    }
+    return obtainStreamForDevice(device);
+  }
+
+  if (value === "screen") {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+      const message = "La capture d'écran n'est pas disponible dans ce navigateur.";
+      setSystemSourceStatus(message, "error");
+      return { stream: null, label: "", message, level: "error" };
+    }
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({ audio: { systemAudio: "include", suppressLocalAudioPlayback: false }, video: false });
+      setSystemSourceStatus("Capture d'écran avec audio système activée.", "success");
+      return { stream, label: "Capture d'écran" };
+    } catch (err) {
+      const message = err && err.message ? err.message : "Capture d'écran annulée.";
+      setSystemSourceStatus(message, "warning");
+      return { stream: null, label: "", message, level: "warning" };
+    }
+  }
+
+  const device = audioInputs.find(d => d.deviceId === value);
+  if (!device) {
+    const message = "Périphérique introuvable. Actualisez la liste.";
+    setSystemSourceStatus(message, "warning");
+    return { stream: null, label: "", message, level: "warning" };
+  }
+  return obtainStreamForDevice(device);
+}
+
+async function obtainStreamForDevice(device) {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia(buildSystemConstraints(device.deviceId));
+    setSystemSourceStatus(`Son du PC : ${device.label || "mixage"}.`, "success");
+    return { stream, label: device.label || "Mixage système" };
+  } catch (err) {
+    const message = err && err.message ? err.message : "Accès refusé au périphérique audio.";
+    setSystemSourceStatus(message, "error");
+    return { stream: null, label: device.label || "", message, level: "error" };
+  }
+}
+
+async function getSystemAudioStream(micStream) {
+  const direct = await tryDirectSystemAudio(micStream);
+  if (direct && direct.stream) {
+    setSystemSourceStatus(`Son du PC : ${direct.label || "capture automatique"}.`, "success");
+    return { stream: direct.stream, label: direct.label || "Mixage système" };
+  }
+  return obtainSystemAudioStreamFromSelection();
+}
+
+async function startRecording() {
+  if (!recordBtn) return;
+  if (!navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+    updateRecordingHint("Enregistrement non supporté sur ce navigateur.", true);
+    return;
+  }
+
+  recordBtn.disabled = true;
+  updateRecordingHint("Initialisation de l'enregistrement…");
+
+  let micStream = null;
+  let systemInfo = { stream: null, label: "" };
+
+  try {
+    micStream = await navigator.mediaDevices.getUserMedia(buildMicConstraints());
+    await refreshSystemDevices();
+    systemInfo = await getSystemAudioStream(micStream);
+
+    recordingStreams = [micStream];
+    const streamsToMix = [micStream];
+    if (systemInfo && systemInfo.stream) {
+      recordingStreams.push(systemInfo.stream);
+      streamsToMix.push(systemInfo.stream);
+    }
+
+    const mixedStream = mixStreams(streamsToMix);
+
+    if (!mixedStream) {
+      throw new Error("Impossible de mixer l'audio dans ce navigateur.");
+    }
+
+    recordingStreams.push(mixedStream);
+    recordingChunks = [];
+    mediaRecorder = new MediaRecorder(mixedStream);
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) {
+        recordingChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = finalizeRecording;
+    mediaRecorder.onerror = (event) => {
+      console.error(event.error || event);
+      updateRecordingHint("Erreur d'enregistrement : " + (event.error ? event.error.message : event.message || event.type), "error");
+      isRecording = false;
+      setRecordButtonState(false);
+      if (recordBtn) recordBtn.disabled = false;
+      stopRecordingStreams();
+      mediaRecorder = null;
+      recordingChunks = [];
+      stopRecordTimer(true);
+    };
+
+    mediaRecorder.start();
+    isRecording = true;
+    setRecordButtonState(true);
+    hadSystemAudio = !!(systemInfo && systemInfo.stream);
+    currentSystemAudioLabel = systemInfo && systemInfo.label ? systemInfo.label : "";
+
+    if (hadSystemAudio) {
+      updateRecordingHint("Enregistrement en cours… micro + audio du PC.", "success");
+    } else {
+      const warningMessage = (systemInfo && systemInfo.message) ? systemInfo.message : "Enregistrement en cours… son du PC introuvable, micro uniquement.";
+      const levelRaw = (systemInfo && systemInfo.level) ? systemInfo.level : "warning";
+      const normalized = normalizeLevel(levelRaw);
+      const displayLevel = normalized === "error" ? "error" : (normalized === "info" ? "info" : "warning");
+      updateRecordingHint(warningMessage, displayLevel);
+    }
+    startRecordTimer();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Impossible de démarrer : " + (err && err.message ? err.message : err), "error");
+    stopRecordingStreams();
+    mediaRecorder = null;
+    recordingChunks = [];
+    isRecording = false;
+    setRecordButtonState(false);
+    stopRecordTimer(true);
+  } finally {
+    recordBtn.disabled = false;
+  }
+}
+
+function stopRecordingAction() {
+  if (!isRecording || !mediaRecorder) return;
+  recordBtn.disabled = true;
+  updateRecordingHint("Finalisation de l'enregistrement…");
+  try {
+    mediaRecorder.stop();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Arrêt impossible : " + err.message, true);
+    recordBtn.disabled = false;
+  }
+}
+
+function finalizeRecording() {
+  const blob = new Blob(recordingChunks, { type: mediaRecorder && mediaRecorder.mimeType ? mediaRecorder.mimeType : "audio/webm" });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `enregistrement_${timestamp}.webm`;
+  const previousRecordedName = lastRecordedFile ? lastRecordedFile.name : null;
+  const previousRecordedSize = lastRecordedFile ? lastRecordedFile.size : null;
+  const newRecordedFile = new File([blob], filename, { type: blob.type, lastModified: Date.now() });
+  lastRecordedFile = newRecordedFile;
+
+  let dataTransfer;
+  try {
+    dataTransfer = new DataTransfer();
+  } catch (err) {
+    console.error(err);
+  }
+
+  if (!dataTransfer) {
+    updateRecordingHint("Enregistrement prêt mais impossible de l'ajouter automatiquement. Téléchargez-le manuellement.", true);
+    stopRecordingStreams();
+    isRecording = false;
+    setRecordButtonState(false);
+    if (recordBtn) recordBtn.disabled = false;
+    mediaRecorder = null;
+    recordingChunks = [];
+    return;
+  }
+
+  dataTransfer.items.add(newRecordedFile);
+
+  Array.from(filesInput.files || []).forEach((file) => {
+    if (previousRecordedName && file.name === previousRecordedName && file.size === previousRecordedSize) {
+      return;
+    }
+    if (file.name === newRecordedFile.name && file.size === newRecordedFile.size) {
+      return;
+    }
+    dataTransfer.items.add(file);
+  });
+
+  filesInput.files = dataTransfer.files;
+  filesInput.dispatchEvent(new Event("change"));
+
+  const usedSystemAudio = hadSystemAudio;
+  const systemLabel = currentSystemAudioLabel;
+  const labelInfo = usedSystemAudio ? (systemLabel ? `micro + ${systemLabel}` : "micro + PC") : "micro uniquement";
+  updateRecordingHint(`Enregistrement ajouté (${labelInfo}) : ${filename}`, usedSystemAudio ? "success" : "warning");
+
+  isRecording = false;
+  setRecordButtonState(false);
+  if (recordBtn) recordBtn.disabled = false;
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  stopRecordTimer();
 }
 
 // ====== Config serveur ======
@@ -386,6 +943,24 @@ resetBtn.addEventListener("click", () => {
   isRunning = false;
   setTranscribing(false);
 
+  if (isRecording && mediaRecorder) {
+    try { mediaRecorder.stop(); } catch (_) { /* noop */ }
+  }
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  isRecording = false;
+  lastRecordedFile = null;
+  setRecordButtonState(false);
+  if (recordBtn) {
+    recordBtn.disabled = false;
+  }
+  updateRecordingHint("");
+  stopRecordTimer(true);
+  if (systemSourceSelect) {
+    updateSystemSourceSummary();
+  }
+
   // reset visuel du formulaire
   form.reset();
   statusSection.hidden = true;
@@ -416,3 +991,39 @@ filesInput.addEventListener("change", computeTotalDuration);
 fillModelOptions();
 fillLangOptions();
 updateEstimate();
+
+if (!navigator.mediaDevices && systemSourceWrap) {
+  systemSourceWrap.style.display = "none";
+}
+
+if (systemSourceRefreshBtn) {
+  systemSourceRefreshBtn.addEventListener("click", () => {
+    refreshSystemDevices();
+  });
+}
+
+if (systemSourceSelect) {
+  systemSourceSelect.addEventListener("change", updateSystemSourceSummary);
+}
+
+if (navigator.mediaDevices && navigator.mediaDevices.addEventListener) {
+  navigator.mediaDevices.addEventListener("devicechange", () => {
+    refreshSystemDevices();
+  });
+}
+
+if (systemSourceSelect) {
+  refreshSystemDevices();
+}
+
+if (recordBtn) {
+  setRecordButtonState(false);
+  resetRecordTimerDisplay();
+  recordBtn.addEventListener("click", () => {
+    if (isRecording) {
+      stopRecordingAction();
+    } else {
+      startRecording();
+    }
+  });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -131,6 +131,141 @@ h1 {
 
 .field.full { grid-column: 1 / -1; }
 
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.icon-button:hover {
+  background: var(--panel-border);
+}
+
+.icon-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.icon-button.mini {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 13px;
+}
+
+.record-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-button.record {
+  gap: 6px;
+  background: transparent;
+  border: 1px solid #e33c3c;
+  color: #e33c3c;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.icon-button.record .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #e33c3c;
+  display: inline-block;
+}
+
+.icon-button.record.is-recording,
+.icon-button.record.is-recording:hover {
+  background: #e33c3c;
+  color: #fff;
+  border-color: #b92d2d;
+}
+
+.icon-button.record.is-recording .dot {
+  background: #fff;
+}
+
+.icon-button.record[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.recording-source-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.recording-source-wrap select {
+  max-width: 360px;
+}
+
+.recording-source-wrap .field-label-row {
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+#recording-hint {
+  min-height: 18px;
+}
+
+#recording-hint.is-error {
+  color: #e33c3c;
+}
+
+#recording-hint.is-warning {
+  color: #f59f00;
+}
+
+#recording-hint.is-success {
+  color: #1e9b6a;
+}
+
+#system-source-status {
+  min-height: 18px;
+}
+
+#system-source-status.is-error {
+  color: #e33c3c;
+}
+
+#system-source-status.is-warning {
+  color: #f59f00;
+}
+
+#system-source-status.is-success {
+  color: #1e9b6a;
+}
+
+.record-timer {
+  font-family: "SFMono-Regular", "Roboto Mono", "Menlo", monospace;
+  font-size: 14px;
+  color: var(--muted);
+  min-width: 72px;
+  text-align: right;
+}
+
+.record-timer.is-recording {
+  color: #e33c3c;
+}
+
 label {
   color: var(--muted);
   font-size: 14px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,9 +68,30 @@
         </div>
 
         <div class="field full">
-          <label for="files">Fichiers audio</label>
+          <div class="field-label-row">
+            <label for="files">Fichiers audio</label>
+            <div class="record-controls">
+              <button id="record-btn" type="button" class="icon-button record">
+                <span class="dot" aria-hidden="true"></span>
+                Enregistrer
+              </button>
+              <span id="record-timer" class="record-timer">00:00:00</span>
+            </div>
+          </div>
           <input id="files" name="files" type="file" multiple accept=".mp3,.wav,.m4a,.flac" />
           <small>Formats : mp3, wav, m4a, flac</small>
+          <small id="recording-hint"></small>
+          <div id="system-source-wrap" class="recording-source-wrap">
+            <div class="field-label-row">
+              <label for="system-source">Son du PC</label>
+              <button id="system-source-refresh" type="button" class="icon-button mini" title="Actualiser les périphériques audio">↻</button>
+            </div>
+            <select id="system-source">
+              <option value="auto" selected>Auto (mixage système si disponible)</option>
+              <option value="none">Aucun (micro uniquement)</option>
+            </select>
+            <small id="system-source-status" class="muted"></small>
+          </div>
           <small id="estimate"></small>
         </div>
 


### PR DESCRIPTION
## Summary
- add a system-audio source selector with refresh controls next to the in-app recorder so users can mix microphone and PC output without screen sharing prompts
- detect loopback/stereo-mix devices automatically, fall back to manual selection or optional screen capture, and mix streams via AudioContext before feeding the MediaRecorder
- surface status and hint colors for recording/system source states and persist the timer/controls styling updates

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_b_68f7458e790083339c2b3e8d66cd343c