### PR TITLE
Improve system audio capture for recorder

### DIFF
--- a/server.py
+++ b/server.py
@@ -6,13 +6,16 @@ import pathlib
 import threading
 import time
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from pathlib import Path
 
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+
+import av
+from av.audio.resampler import AudioResampler
 
 # ----- LOCAL (faster-whisper)
 from faster_whisper import WhisperModel
@@ -45,6 +48,8 @@ UPLOAD_DIR = BASE_DIR / "uploads"
 TRANS_DIR  = BASE_DIR / "transcriptions"
 TEMP_DIR   = BASE_DIR / "tmp"
 ASSETS_DIR = BASE_DIR / "assets"
+
+MAX_OPENAI_CHUNK_SECONDS = 20 * 60
 
 # Répertoire persistant pour les modèles Whisper.
 # Peut être personnalisé via la variable d'environnement WHISPER_MODELS_DIR.
@@ -427,6 +432,125 @@ def _make_openai_client(api_key: Optional[str]):
         raise RuntimeError("Aucune clé API fournie (champ vide et OPENAI_API_KEY non défini).")
     return OpenAI(api_key=key)
 
+def _format_seconds_hms(seconds: float) -> str:
+    total = max(0, int(round(seconds)))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+def _probe_audio_duration(path: Path) -> Optional[float]:
+    try:
+        with av.open(str(path)) as container:
+            stream = next((s for s in container.streams if s.type == "audio"), None)
+            if stream is None:
+                return None
+            if stream.duration and stream.time_base:
+                return float(stream.duration * stream.time_base)
+            if container.duration:
+                return float(container.duration / av.time_base)
+    except Exception:
+        return None
+    return None
+
+def _split_audio_file(source: Path, chunk_dir: Path, max_seconds: int) -> List[Path]:
+    chunk_paths: List[Path] = []
+    with av.open(str(source)) as container:
+        audio_stream = next((s for s in container.streams if s.type == "audio"), None)
+        if audio_stream is None:
+            raise RuntimeError("Flux audio introuvable")
+
+        rate = audio_stream.rate or getattr(audio_stream.codec_context, "sample_rate", None) or 16000
+        channels = getattr(audio_stream.codec_context, "channels", None) or (
+            audio_stream.layout.channels if getattr(audio_stream, "layout", None) else 1
+        )
+        layout_name = (
+            audio_stream.layout.name
+            if getattr(audio_stream, "layout", None)
+            else ("mono" if channels == 1 else "stereo")
+        )
+
+        resampler = AudioResampler(format="s16", layout=layout_name, rate=rate)
+
+        chunk_index = 0
+        writer = None
+        out_stream = None
+        chunk_path: Optional[Path] = None
+        chunk_time = 0.0
+
+        def open_writer():
+            nonlocal writer, out_stream, chunk_path, chunk_time, chunk_index
+            chunk_path = chunk_dir / f"{source.stem}_part{chunk_index + 1:02d}.wav"
+            writer = av.open(str(chunk_path), "w", format="wav")
+            out_stream = writer.add_stream("pcm_s16le", rate=rate)
+            try:
+                out_stream.layout = layout_name
+            except Exception:
+                out_stream.channels = channels
+            chunk_time = 0.0
+
+        def close_writer():
+            nonlocal writer, out_stream, chunk_index, chunk_path
+            if not writer:
+                return
+            for packet in out_stream.encode(None):
+                writer.mux(packet)
+            writer.close()
+            if chunk_path is not None:
+                chunk_paths.append(chunk_path)
+            writer = None
+            out_stream = None
+            chunk_path = None
+            chunk_index += 1
+
+        for frame in container.decode(audio_stream):
+            if writer is None:
+                open_writer()
+
+            frame_duration = float(frame.samples or 0) / float(frame.sample_rate or rate or 1)
+
+            for resampled in resampler.resample(frame):
+                resampled.pts = None
+                for packet in out_stream.encode(resampled):
+                    writer.mux(packet)
+
+            chunk_time += frame_duration
+
+            if chunk_time >= max_seconds:
+                for resampled in resampler.resample(None):
+                    resampled.pts = None
+                    for packet in out_stream.encode(resampled):
+                        writer.mux(packet)
+                close_writer()
+
+        if writer is not None:
+            for resampled in resampler.resample(None):
+                resampled.pts = None
+                for packet in out_stream.encode(resampled):
+                    writer.mux(packet)
+            close_writer()
+
+    if not chunk_paths:
+        raise RuntimeError("Découpage impossible : sortie vide")
+    return chunk_paths
+
+def _prepare_api_chunks(job_id: str, file_index: int, source_path: Path) -> Tuple[List[Path], Optional[Path], Optional[float], bool]:
+    duration = _probe_audio_duration(source_path)
+    if duration is not None and duration <= MAX_OPENAI_CHUNK_SECONDS + 1:
+        return [source_path], None, duration, False
+
+    chunk_dir = TEMP_DIR / job_id / f"chunks_{file_index:02d}"
+    if chunk_dir.exists():
+        shutil.rmtree(chunk_dir, ignore_errors=True)
+    chunk_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        chunks = _split_audio_file(source_path, chunk_dir, MAX_OPENAI_CHUNK_SECONDS)
+        return chunks, chunk_dir, duration, True
+    except Exception as exc:
+        shutil.rmtree(chunk_dir, ignore_errors=True)
+        append_log(job_id, f"[WARN] Découpage impossible pour {source_path.name} : {exc}. Envoi du fichier complet.")
+        return [source_path], None, duration, False
+
 def _run_cloud(job_id: str, client: "OpenAI"):
     with JOBS_LOCK:
         job = JOBS[job_id]
@@ -438,14 +562,34 @@ def _run_cloud(job_id: str, client: "OpenAI"):
     for idx, fmeta in enumerate(job["files"]):
         update_file_status(job_id, idx, "running")
         append_log(job_id, f"→ Envoi à OpenAI : {fmeta['name']}")
+        cleanup_dir: Optional[Path] = None
         try:
-            with open(fmeta["path"], "rb") as fh:
-                resp = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=fh,
-                    language=lang,
-                )
-            text = (getattr(resp, "text", "") or "").strip()
+            source_path = Path(fmeta["path"])
+            chunk_paths, cleanup_dir, detected_duration, was_split = _prepare_api_chunks(job_id, idx, source_path)
+            if detected_duration is not None:
+                append_log(job_id, f"  · Durée détectée : {_format_seconds_hms(detected_duration)}")
+            if was_split and len(chunk_paths) > 1:
+                append_log(job_id, f"  · Découpe en {len(chunk_paths)} segments de ≤ 20 minutes")
+
+            collected_texts: List[str] = []
+            total_chunks = max(len(chunk_paths), 1)
+            for chunk_pos, chunk_path in enumerate(chunk_paths, start=1):
+                if len(chunk_paths) > 1:
+                    append_log(job_id, f"    Segment {chunk_pos}/{len(chunk_paths)} : {chunk_path.name}")
+                with open(chunk_path, "rb") as fh:
+                    resp = client.audio.transcriptions.create(
+                        model=model_name,
+                        file=fh,
+                        language=lang,
+                    )
+                text_part = (getattr(resp, "text", "") or "").strip()
+                if text_part:
+                    collected_texts.append(text_part)
+
+                set_file_progress(job_id, idx, chunk_pos / total_chunks)
+                set_job_progress(job_id, (idx + (chunk_pos / total_chunks)) / max(total, 1))
+
+            text = "\n\n".join(collected_texts).strip()
 
             processed = text
             prompt_tmpl = OUTPUT_PROMPTS.get(output_type)
@@ -481,6 +625,9 @@ def _run_cloud(job_id: str, client: "OpenAI"):
         except Exception as e:
             update_file_status(job_id, idx, "error", error=str(e))
             append_log(job_id, f"[ERREUR API] {fmeta['name']} : {e}")
+        finally:
+            if cleanup_dir is not None:
+                shutil.rmtree(cleanup_dir, ignore_errors=True)
 
         set_job_progress(job_id, (idx + 1) / max(total, 1))
 

--- a/static/app.js
+++ b/static/app.js
@@ -11,6 +11,9 @@ const langSelect = document.getElementById("lang");
 const filesInput = document.getElementById("files");
 const startBtn = document.getElementById("start");
 const resetBtn = document.getElementById("reset");
+const recordBtn = document.getElementById("record-btn");
+const recordingHint = document.getElementById("recording-hint");
+const recordTimer = document.getElementById("record-timer");
 
 const statusSection = document.getElementById("status");
 const progressBar = document.getElementById("progress");
@@ -57,6 +60,17 @@ let lastLogLength = 0;
 let isRunning = false;
 let totalDurationMin = 0;
 
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingStreams = [];
+let lastRecordedFile = null;
+let isRecording = false;
+let recordTimerInterval = null;
+let recordStartTime = 0;
+let audioContext = null;
+let audioDestination = null;
+let audioNodes = [];
+
 let particlesPromise = null;
 function loadParticles() {
   if (!particlesPromise) {
@@ -72,6 +86,299 @@ function setTranscribing(active) {
     if (active) p.start();
     else p.stop();
   });
+}
+
+function setRecordButtonState(active) {
+  if (!recordBtn) return;
+  recordBtn.classList.toggle("is-recording", !!active);
+  recordBtn.innerHTML = `<span class="dot" aria-hidden="true"></span>${active ? "Arrêter" : "Enregistrer"}`;
+}
+
+function resetRecordTimerDisplay() {
+  if (!recordTimer) return;
+  recordTimer.textContent = "00:00:00";
+  recordTimer.classList.remove("is-recording");
+}
+
+function updateRecordTimerDisplay() {
+  if (!recordTimer) return;
+  const elapsed = Math.max(0, Math.floor((Date.now() - recordStartTime) / 1000));
+  const hours = String(Math.floor(elapsed / 3600)).padStart(2, "0");
+  const minutes = String(Math.floor((elapsed % 3600) / 60)).padStart(2, "0");
+  const seconds = String(elapsed % 60).padStart(2, "0");
+  recordTimer.textContent = `${hours}:${minutes}:${seconds}`;
+}
+
+function startRecordTimer() {
+  if (!recordTimer) return;
+  recordStartTime = Date.now();
+  recordTimer.classList.add("is-recording");
+  updateRecordTimerDisplay();
+  if (recordTimerInterval) clearInterval(recordTimerInterval);
+  recordTimerInterval = setInterval(updateRecordTimerDisplay, 500);
+}
+
+function stopRecordTimer(resetDisplay = false) {
+  if (recordTimerInterval) {
+    clearInterval(recordTimerInterval);
+    recordTimerInterval = null;
+  }
+  if (!recordTimer) return;
+  if (!resetDisplay) {
+    updateRecordTimerDisplay();
+  }
+  recordTimer.classList.remove("is-recording");
+  if (resetDisplay) {
+    recordTimer.textContent = "00:00:00";
+  }
+}
+
+function updateRecordingHint(text = "", isError = false) {
+  if (!recordingHint) return;
+  recordingHint.textContent = text;
+  recordingHint.style.color = isError ? "#e33c3c" : "var(--muted)";
+}
+
+function stopRecordingStreams() {
+  recordingStreams.forEach((stream) => {
+    if (!stream) return;
+    stream.getTracks().forEach(track => {
+      try { track.stop(); } catch (_) { /* noop */ }
+    });
+  });
+  recordingStreams = [];
+
+  audioNodes.forEach(node => {
+    if (!node) return;
+    const { sourceNode, gainNode } = node;
+    try { sourceNode.disconnect(); } catch (_) { /* noop */ }
+    try { gainNode.disconnect(); } catch (_) { /* noop */ }
+  });
+  audioNodes = [];
+
+  if (audioDestination && audioDestination.stream) {
+    audioDestination.stream.getTracks().forEach(track => {
+      try { track.stop(); } catch (_) { /* noop */ }
+    });
+  }
+  audioDestination = null;
+
+  if (audioContext) {
+    try { audioContext.close(); } catch (_) { /* noop */ }
+  }
+  audioContext = null;
+}
+
+async function getSystemAudioStream() {
+  if (!navigator.mediaDevices || typeof navigator.mediaDevices.getDisplayMedia !== "function") {
+    throw new Error("La capture du son système n'est pas supportée sur ce navigateur.");
+  }
+
+  const attempts = [
+    { audio: { systemAudio: "include", suppressLocalAudioPlayback: false }, video: false },
+    { audio: { systemAudio: "include", selfBrowserSurface: "include", suppressLocalAudioPlayback: false }, video: false },
+    { audio: true, video: false },
+  ];
+
+  let lastError = null;
+  for (const constraints of attempts) {
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia(constraints);
+      if (!stream) continue;
+      stream.getVideoTracks().forEach(track => {
+        try { track.stop(); } catch (_) { /* noop */ }
+      });
+      if (stream.getAudioTracks().length) {
+        return stream;
+      }
+      stream.getTracks().forEach(track => {
+        try { track.stop(); } catch (_) { /* noop */ }
+      });
+    } catch (err) {
+      lastError = err;
+      if (err && err.name === "NotAllowedError") {
+        throw err;
+      }
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error("Aucun flux audio système disponible.");
+}
+
+async function startRecording() {
+  if (!recordBtn) return;
+  if (!navigator.mediaDevices || typeof MediaRecorder === "undefined") {
+    updateRecordingHint("Enregistrement non supporté sur ce navigateur.", true);
+    return;
+  }
+
+  recordBtn.disabled = true;
+  updateRecordingHint("Initialisation de l'enregistrement…");
+
+  try {
+    const micStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      }
+    });
+    recordingStreams = [micStream];
+    const systemStream = await getSystemAudioStream();
+
+    const systemTracks = (systemStream && systemStream.getAudioTracks()) || [];
+    const audioTracks = [
+      ...micStream.getAudioTracks(),
+      ...systemTracks
+    ].filter(Boolean);
+
+    if (!audioTracks.length) {
+      throw new Error("Aucune piste audio détectée.");
+    }
+
+    const Context = window.AudioContext || window.webkitAudioContext;
+    if (!Context) {
+      throw new Error("Le mixage audio n'est pas supporté sur ce navigateur.");
+    }
+
+    audioContext = new Context();
+    if (audioContext.state === "suspended") {
+      try { await audioContext.resume(); } catch (_) { /* noop */ }
+    }
+
+    audioDestination = audioContext.createMediaStreamDestination();
+    audioNodes = [];
+
+    audioTracks.forEach(track => {
+      const trackStream = new MediaStream([track]);
+      const sourceNode = audioContext.createMediaStreamSource(trackStream);
+      const gainNode = audioContext.createGain();
+      gainNode.gain.value = 1;
+      sourceNode.connect(gainNode).connect(audioDestination);
+      audioNodes.push({ sourceNode, gainNode });
+    });
+
+    if (systemStream) {
+      systemTracks.forEach(track => {
+        track.onended = () => {
+          if (isRecording) {
+            updateRecordingHint("Le son du système s'est arrêté. L'enregistrement va se terminer.", true);
+            stopRecordingAction();
+          }
+        };
+      });
+      recordingStreams.push(systemStream);
+    }
+
+    recordingChunks = [];
+    mediaRecorder = new MediaRecorder(audioDestination.stream);
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) {
+        recordingChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = finalizeRecording;
+    mediaRecorder.onerror = (event) => {
+      console.error(event.error || event);
+      updateRecordingHint("Erreur d'enregistrement : " + (event.error ? event.error.message : event.message || event.type), true);
+      isRecording = false;
+      setRecordButtonState(false);
+      if (recordBtn) recordBtn.disabled = false;
+      stopRecordingStreams();
+      mediaRecorder = null;
+      recordingChunks = [];
+      stopRecordTimer(true);
+    };
+
+    mediaRecorder.start();
+    isRecording = true;
+    setRecordButtonState(true);
+    updateRecordingHint("Enregistrement en cours… micro et son système capturés.");
+    startRecordTimer();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Impossible de démarrer : " + (err && err.message ? err.message : err), true);
+    stopRecordingStreams();
+    mediaRecorder = null;
+    recordingChunks = [];
+    isRecording = false;
+    setRecordButtonState(false);
+    stopRecordTimer(true);
+  } finally {
+    recordBtn.disabled = false;
+  }
+}
+
+function stopRecordingAction() {
+  if (!isRecording || !mediaRecorder) return;
+  recordBtn.disabled = true;
+  updateRecordingHint("Finalisation de l'enregistrement…");
+  try {
+    mediaRecorder.stop();
+  } catch (err) {
+    console.error(err);
+    updateRecordingHint("Arrêt impossible : " + err.message, true);
+    recordBtn.disabled = false;
+  }
+}
+
+function finalizeRecording() {
+  const blob = new Blob(recordingChunks, { type: mediaRecorder && mediaRecorder.mimeType ? mediaRecorder.mimeType : "audio/webm" });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `enregistrement_${timestamp}.webm`;
+  const previousRecordedName = lastRecordedFile ? lastRecordedFile.name : null;
+  const previousRecordedSize = lastRecordedFile ? lastRecordedFile.size : null;
+  const newRecordedFile = new File([blob], filename, { type: blob.type, lastModified: Date.now() });
+  lastRecordedFile = newRecordedFile;
+
+  let dataTransfer;
+  try {
+    dataTransfer = new DataTransfer();
+  } catch (err) {
+    console.error(err);
+  }
+
+  if (!dataTransfer) {
+    updateRecordingHint("Enregistrement prêt mais impossible de l'ajouter automatiquement. Téléchargez-le manuellement.", true);
+    stopRecordingStreams();
+    isRecording = false;
+    setRecordButtonState(false);
+    if (recordBtn) recordBtn.disabled = false;
+    mediaRecorder = null;
+    recordingChunks = [];
+    return;
+  }
+
+  dataTransfer.items.add(newRecordedFile);
+
+  Array.from(filesInput.files || []).forEach((file) => {
+    if (previousRecordedName && file.name === previousRecordedName && file.size === previousRecordedSize) {
+      return;
+    }
+    if (file.name === newRecordedFile.name && file.size === newRecordedFile.size) {
+      return;
+    }
+    dataTransfer.items.add(file);
+  });
+
+  filesInput.files = dataTransfer.files;
+  filesInput.dispatchEvent(new Event("change"));
+
+  updateRecordingHint(`Enregistrement ajouté : ${filename}`);
+
+  isRecording = false;
+  setRecordButtonState(false);
+  if (recordBtn) recordBtn.disabled = false;
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  stopRecordTimer();
 }
 
 // ====== Config serveur ======
@@ -386,6 +693,21 @@ resetBtn.addEventListener("click", () => {
   isRunning = false;
   setTranscribing(false);
 
+  if (isRecording && mediaRecorder) {
+    try { mediaRecorder.stop(); } catch (_) { /* noop */ }
+  }
+  stopRecordingStreams();
+  mediaRecorder = null;
+  recordingChunks = [];
+  isRecording = false;
+  lastRecordedFile = null;
+  setRecordButtonState(false);
+  if (recordBtn) {
+    recordBtn.disabled = false;
+  }
+  updateRecordingHint("");
+  stopRecordTimer(true);
+
   // reset visuel du formulaire
   form.reset();
   statusSection.hidden = true;
@@ -416,3 +738,15 @@ filesInput.addEventListener("change", computeTotalDuration);
 fillModelOptions();
 fillLangOptions();
 updateEstimate();
+
+if (recordBtn) {
+  setRecordButtonState(false);
+  resetRecordTimerDisplay();
+  recordBtn.addEventListener("click", () => {
+    if (isRecording) {
+      stopRecordingAction();
+    } else {
+      startRecording();
+    }
+  });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -131,6 +131,64 @@ h1 {
 
 .field.full { grid-column: 1 / -1; }
 
+.field-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.record-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-button.record {
+  gap: 6px;
+  background: transparent;
+  border: 1px solid #e33c3c;
+  color: #e33c3c;
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.icon-button.record .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #e33c3c;
+  display: inline-block;
+}
+
+.icon-button.record.is-recording,
+.icon-button.record.is-recording:hover {
+  background: #e33c3c;
+  color: #fff;
+  border-color: #b92d2d;
+}
+
+.icon-button.record.is-recording .dot {
+  background: #fff;
+}
+
+.icon-button.record[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.record-timer {
+  font-family: "SFMono-Regular", "Roboto Mono", "Menlo", monospace;
+  font-size: 14px;
+  color: var(--muted);
+  min-width: 72px;
+  text-align: right;
+}
+
+.record-timer.is-recording {
+  color: #e33c3c;
+}
+
 label {
   color: var(--muted);
   font-size: 14px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,9 +68,19 @@
         </div>
 
         <div class="field full">
-          <label for="files">Fichiers audio</label>
+          <div class="field-label-row">
+            <label for="files">Fichiers audio</label>
+            <div class="record-controls">
+              <button id="record-btn" type="button" class="icon-button record">
+                <span class="dot" aria-hidden="true"></span>
+                Enregistrer
+              </button>
+              <span id="record-timer" class="record-timer">00:00:00</span>
+            </div>
+          </div>
           <input id="files" name="files" type="file" multiple accept=".mp3,.wav,.m4a,.flac" />
           <small>Formats : mp3, wav, m4a, flac</small>
+          <small id="recording-hint"></small>
           <small id="estimate"></small>
         </div>
 


### PR DESCRIPTION
## Summary
- mix microphone and system audio streams in the browser so both feeds are captured reliably
- request system audio with audio-only display capture options and tear down the audio graph after recordings
- update recording status hints and auto-stop when the system audio feed ends

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_b_68f7458e790083339c2b3e8d66cd343c